### PR TITLE
[Fix]: gradle build 순서 파일 생성 후로 이동

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,11 +17,6 @@ jobs:
           distribution: 'corretto'
           java-version: '21'
 
-      - name: Grant execute permission for gradlew
-        run: |
-          chmod +x gradlew
-          ./gradlew build -x test
-
       - name: Generate afterInstall.sh
         run: |
           mkdir -p ./scripts
@@ -71,6 +66,11 @@ jobs:
           ${{ secrets.ABILITY_ANALYSIS_PROMPT }}
           EOF
         shell: bash
+
+      - name: Grant execute permission for gradlew
+        run: |
+          chmod +x gradlew
+          ./gradlew build -x test
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #

### 💡 작업내용
- application-secret 등의 파일 생성 전에 gradle build 코드가 있어서 같이 빌드가 되지 않는 문제를 발견하여 빌드 코드 순서 이동

### 📸 스크린샷(선택)

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
