### PR TITLE
[Feat/#4] 에러 발생 시 Discord 알림 전송 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	// Open Ai
 	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
+	// AOP
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 dependencyManagement {

--- a/src/main/java/corecord/dev/common/exception/GeneralException.java
+++ b/src/main/java/corecord/dev/common/exception/GeneralException.java
@@ -1,13 +1,13 @@
 package corecord.dev.common.exception;
 
-import corecord.dev.common.status.ErrorStatus;
+import corecord.dev.common.base.BaseErrorStatus;
 import lombok.Getter;
 
 @Getter
 public class GeneralException extends RuntimeException{
-    private final ErrorStatus errorStatus;
+    protected final BaseErrorStatus errorStatus;
 
-    public GeneralException(ErrorStatus errorStatus) {
+    public GeneralException(BaseErrorStatus errorStatus) {
         super(errorStatus.getMessage());
         this.errorStatus = errorStatus;
     }

--- a/src/main/java/corecord/dev/common/exception/GeneralExceptionAdvice.java
+++ b/src/main/java/corecord/dev/common/exception/GeneralExceptionAdvice.java
@@ -2,13 +2,6 @@ package corecord.dev.common.exception;
 
 import corecord.dev.common.response.ApiResponse;
 import corecord.dev.common.status.ErrorStatus;
-import corecord.dev.domain.ability.exception.AbilityException;
-import corecord.dev.domain.analysis.exception.AnalysisException;
-import corecord.dev.domain.auth.exception.TokenException;
-import corecord.dev.domain.chat.exception.ChatException;
-import corecord.dev.domain.folder.exception.FolderException;
-import corecord.dev.domain.record.exception.RecordException;
-import corecord.dev.domain.user.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -32,55 +25,6 @@ import java.util.stream.Collectors;
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
-
-    // UserException 처리
-    @ExceptionHandler(UserException.class)
-    public ResponseEntity<ApiResponse<Void>> handleUserException(UserException e) {
-        log.warn(">>>>>>>>UserException: {}", e.getErrorStatus().getMessage());
-        return ApiResponse.error(e.getErrorStatus());
-    }
-
-    // TokenException 처리
-    @ExceptionHandler(TokenException.class)
-    public ResponseEntity<ApiResponse<Void>> handleTokenException(TokenException e) {
-        log.warn(">>>>>>>>TokenException: {}", e.getErrorStatus().getMessage());
-        return ApiResponse.error(e.getErrorStatus());
-    }
-
-    // FolderException 처리
-    @ExceptionHandler(FolderException.class)
-    public ResponseEntity<ApiResponse<Void>> handleFolderException(FolderException e) {
-        log.warn(">>>>>>>>FolderException: {}", e.getErrorStatus().getMessage());
-        return ApiResponse.error(e.getErrorStatus());
-    }
-
-    // RecordException 처리
-    @ExceptionHandler(RecordException.class)
-    public ResponseEntity<ApiResponse<Void>> handleRecordException(RecordException e) {
-        log.warn(">>>>>>>>RecordException: {}", e.getErrorStatus().getMessage());
-        return ApiResponse.error(e.getErrorStatus());
-    }
-
-    // AnalysisException 처리
-    @ExceptionHandler(AnalysisException.class)
-    public ResponseEntity<ApiResponse<Void>> handleAnalysisException(AnalysisException e) {
-        log.warn(">>>>>>>>AnalysisException: {}", e.getErrorStatus().getMessage());
-        return ApiResponse.error(e.getErrorStatus());
-    }
-
-    // AbilityException 처리
-    @ExceptionHandler(AbilityException.class)
-    public ResponseEntity<ApiResponse<Void>> handleAbilityException(AbilityException e) {
-        log.warn(">>>>>>>>AbilityException: {}", e.getErrorStatus().getMessage());
-        return ApiResponse.error(e.getErrorStatus());
-    }
-
-    // ChatException 처리
-    @ExceptionHandler(ChatException.class)
-    public ResponseEntity<ApiResponse<Void>> handleChatException(ChatException e) {
-        log.warn(">>>>>>>>ChatException: {}", e.getErrorStatus().getMessage());
-        return ApiResponse.error(e.getErrorStatus());
-    }
 
     // GeneralException 처리
     @ExceptionHandler(GeneralException.class)

--- a/src/main/java/corecord/dev/common/exception/GeneralExceptionAdvice.java
+++ b/src/main/java/corecord/dev/common/exception/GeneralExceptionAdvice.java
@@ -1,6 +1,5 @@
 package corecord.dev.common.exception;
 
-import corecord.dev.common.log.discord.DiscordAlarmSender;
 import corecord.dev.common.response.ApiResponse;
 import corecord.dev.common.status.ErrorStatus;
 import corecord.dev.domain.ability.exception.AbilityException;
@@ -10,12 +9,10 @@ import corecord.dev.domain.chat.exception.ChatException;
 import corecord.dev.domain.folder.exception.FolderException;
 import corecord.dev.domain.record.exception.RecordException;
 import corecord.dev.domain.user.exception.UserException;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -35,58 +32,54 @@ import java.util.stream.Collectors;
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
-    private final DiscordAlarmSender discordAlarmSender;
 
     // UserException 처리
     @ExceptionHandler(UserException.class)
     public ResponseEntity<ApiResponse<Void>> handleUserException(UserException e) {
-        log.warn(">>>>>>>>UserException: {}", e.getUserErrorStatus().getMessage());
-        return ApiResponse.error(e.getUserErrorStatus());
+        log.warn(">>>>>>>>UserException: {}", e.getErrorStatus().getMessage());
+        return ApiResponse.error(e.getErrorStatus());
     }
 
     // TokenException 처리
     @ExceptionHandler(TokenException.class)
     public ResponseEntity<ApiResponse<Void>> handleTokenException(TokenException e) {
-        log.warn(">>>>>>>>TokenException: {}", e.getTokenErrorStatus().getMessage());
-        return ApiResponse.error(e.getTokenErrorStatus());
+        log.warn(">>>>>>>>TokenException: {}", e.getErrorStatus().getMessage());
+        return ApiResponse.error(e.getErrorStatus());
     }
 
     // FolderException 처리
     @ExceptionHandler(FolderException.class)
     public ResponseEntity<ApiResponse<Void>> handleFolderException(FolderException e) {
-        log.warn(">>>>>>>>FolderException: {}", e.getFolderErrorStatus().getMessage());
-        return ApiResponse.error(e.getFolderErrorStatus());
+        log.warn(">>>>>>>>FolderException: {}", e.getErrorStatus().getMessage());
+        return ApiResponse.error(e.getErrorStatus());
     }
 
     // RecordException 처리
     @ExceptionHandler(RecordException.class)
     public ResponseEntity<ApiResponse<Void>> handleRecordException(RecordException e) {
-        log.warn(">>>>>>>>RecordException: {}", e.getRecordErrorStatus().getMessage());
-        return ApiResponse.error(e.getRecordErrorStatus());
+        log.warn(">>>>>>>>RecordException: {}", e.getErrorStatus().getMessage());
+        return ApiResponse.error(e.getErrorStatus());
     }
 
     // AnalysisException 처리
     @ExceptionHandler(AnalysisException.class)
     public ResponseEntity<ApiResponse<Void>> handleAnalysisException(AnalysisException e) {
-        log.warn(">>>>>>>>AnalysisException: {}", e.getAnalysisErrorStatus().getMessage());
-        return ApiResponse.error(e.getAnalysisErrorStatus());
+        log.warn(">>>>>>>>AnalysisException: {}", e.getErrorStatus().getMessage());
+        return ApiResponse.error(e.getErrorStatus());
     }
 
     // AbilityException 처리
     @ExceptionHandler(AbilityException.class)
     public ResponseEntity<ApiResponse<Void>> handleAbilityException(AbilityException e) {
-        log.warn(">>>>>>>>AbilityException: {}", e.getAbilityErrorStatus().getMessage());
-        return ApiResponse.error(e.getAbilityErrorStatus());
+        log.warn(">>>>>>>>AbilityException: {}", e.getErrorStatus().getMessage());
+        return ApiResponse.error(e.getErrorStatus());
     }
 
     // ChatException 처리
     @ExceptionHandler(ChatException.class)
-    public ResponseEntity<ApiResponse<Void>> handleChatException(ChatException e, HttpServletRequest request) {
-        if (e.getChatErrorStatus().getHttpStatus() == HttpStatus.INTERNAL_SERVER_ERROR)
-            discordAlarmSender.sendDiscordAlarm(e, request);
-
-        log.warn(">>>>>>>>ChatException: {}", e.getChatErrorStatus().getMessage());
-        return ApiResponse.error(e.getChatErrorStatus());
+    public ResponseEntity<ApiResponse<Void>> handleChatException(ChatException e) {
+        log.warn(">>>>>>>>ChatException: {}", e.getErrorStatus().getMessage());
+        return ApiResponse.error(e.getErrorStatus());
     }
 
     // GeneralException 처리
@@ -131,8 +124,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
 
     // NullPointerException 처리
     @ExceptionHandler(NullPointerException.class)
-    public ResponseEntity<Object> handleNullPointerException(NullPointerException e, HttpServletRequest request) {
-        discordAlarmSender.sendDiscordAlarm(e, request);
+    public ResponseEntity<Object> handleNullPointerException(NullPointerException e) {
         String errorMessage = "서버에서 예기치 않은 오류가 발생했습니다. 요청을 처리하는 중에 Null 값이 참조되었습니다.";
         logError("NullPointerException", e);
         return ApiResponse.error(ErrorStatus.INTERNAL_SERVER_ERROR, errorMessage);
@@ -163,8 +155,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
 
     // 기타 모든 예외 처리
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleException(Exception e, HttpServletRequest request) {
-        discordAlarmSender.sendDiscordAlarm(e, request);
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         log.error(">>>>>>>>Internal Server Error: {}", e.getMessage());
         e.printStackTrace();
         return ApiResponse.error(ErrorStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/corecord/dev/common/log/discord/DiscordAlarmSender.java
+++ b/src/main/java/corecord/dev/common/log/discord/DiscordAlarmSender.java
@@ -1,0 +1,38 @@
+package corecord.dev.common.log.discord;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Arrays;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DiscordAlarmSender {
+
+    private final Environment environment;
+    @Value("${logging.discord.web-hook-url}")
+    private String webHookUrl;
+
+    private final DiscordUtil discordUtil;
+    private final WebClient webClient = WebClient.create();
+
+    public Void sendDiscordAlarm(Exception exception, HttpServletRequest httpServletRequest) {
+        if (Arrays.asList(environment.getActiveProfiles()).contains("dev")) {
+            return webClient.post()
+                    .uri(webHookUrl)
+                    .header("Content-Type", "application/json; charset=utf-8")
+                    .header("Accept", "application/json")
+                    .bodyValue(discordUtil.createMessage(exception, httpServletRequest))
+                    .retrieve()
+                    .bodyToMono(void.class)
+                    .block();
+        }
+        return null;
+    }
+}

--- a/src/main/java/corecord/dev/common/log/discord/DiscordAlarmSender.java
+++ b/src/main/java/corecord/dev/common/log/discord/DiscordAlarmSender.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -26,11 +27,10 @@ public class DiscordAlarmSender {
         if (Arrays.asList(environment.getActiveProfiles()).contains("dev")) {
             return webClient.post()
                     .uri(webHookUrl)
-                    .header("Content-Type", "application/json; charset=utf-8")
-                    .header("Accept", "application/json")
+                    .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(discordUtil.createMessage(exception, httpServletRequest))
                     .retrieve()
-                    .bodyToMono(void.class)
+                    .bodyToMono(Void.class)
                     .block();
         }
         return null;

--- a/src/main/java/corecord/dev/common/log/discord/DiscordLoggerAop.java
+++ b/src/main/java/corecord/dev/common/log/discord/DiscordLoggerAop.java
@@ -26,12 +26,15 @@ public class DiscordLoggerAop {
 
     @Before("generalExceptionErrorLoggerExecute()")
     public void serverErrorLogging(JoinPoint joinpoint) {
-        Object[] args = joinpoint.getArgs();
-        GeneralException exception = (GeneralException) args[0];
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        Object[] args = joinpoint.getArgs();
 
-        if (exception.getErrorStatus().getHttpStatus() == HttpStatus.INTERNAL_SERVER_ERROR)
+        if (args[0] instanceof GeneralException exception) {
+            if (exception.getErrorStatus().getHttpStatus() == HttpStatus.INTERNAL_SERVER_ERROR)
+                discordAlarmSender.sendDiscordAlarm(exception, request);
+        } else {
+            Exception exception = (Exception) args[0];
             discordAlarmSender.sendDiscordAlarm(exception, request);
+        }
     }
-
 }

--- a/src/main/java/corecord/dev/common/log/discord/DiscordLoggerAop.java
+++ b/src/main/java/corecord/dev/common/log/discord/DiscordLoggerAop.java
@@ -1,0 +1,37 @@
+package corecord.dev.common.log.discord;
+
+import corecord.dev.common.exception.GeneralException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DiscordLoggerAop {
+
+    private final DiscordAlarmSender discordAlarmSender;
+
+    @Pointcut("execution(* corecord.dev.common.exception.GeneralExceptionAdvice..*(..))")
+    public void generalExceptionErrorLoggerExecute() {}
+
+    @Before("generalExceptionErrorLoggerExecute()")
+    public void serverErrorLogging(JoinPoint joinpoint) {
+        Object[] args = joinpoint.getArgs();
+        GeneralException exception = (GeneralException) args[0];
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        if (exception.getErrorStatus().getHttpStatus() == HttpStatus.INTERNAL_SERVER_ERROR)
+            discordAlarmSender.sendDiscordAlarm(exception, request);
+    }
+
+}

--- a/src/main/java/corecord/dev/common/log/discord/DiscordUtil.java
+++ b/src/main/java/corecord/dev/common/log/discord/DiscordUtil.java
@@ -1,0 +1,62 @@
+package corecord.dev.common.log.discord;
+
+import corecord.dev.common.log.discord.dto.DiscordDto;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.security.Principal;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+
+@Component
+public class DiscordUtil {
+    public DiscordDto.MessageDto createMessage(Exception exception, HttpServletRequest httpServletRequest) {
+        return DiscordDto.MessageDto.builder()
+                .content("# 🚨 서버 에러 발생 🚨")
+                .embeds(List.of(DiscordDto.EmbedDto.builder()
+                                .title("에러 정보")
+                                .description("### 에러 발생 시간\n"
+                                        + ZonedDateTime.now(ZoneId.of("Asia/Seoul")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH시 mm분 ss초"))
+                                        + "\n"
+                                        + "### 요청 엔드포인트\n"
+                                        + getEndPoint(httpServletRequest)
+                                        + "\n"
+                                        + "### 요청 클라이언트\n"
+                                        + getClient(httpServletRequest)
+                                        +"\n"
+                                        + "### 에러 스택 트레이스\n"
+                                        + "```\n"
+                                        + getStackTrace(exception).substring(0, 1000)
+                                        + "\n```")
+                                .build()
+                        )
+                ).build();
+    }
+
+    private String getClient(HttpServletRequest httpServletRequest) {
+        String ip = httpServletRequest.getRemoteAddr();
+
+        Principal principal = httpServletRequest.getUserPrincipal();
+        if (principal != null) {
+            return "[IP] : " + ip + " / [Id] : " + principal.getName();
+        }
+        return "[IP] : " + ip;
+    }
+
+    private String getEndPoint(HttpServletRequest httpServletRequest) {
+        String method = httpServletRequest.getMethod();
+        String url = httpServletRequest.getRequestURI();
+        return method + " " + url;
+    }
+
+    private String getStackTrace(Exception exception) {
+        StringWriter stringWriter = new StringWriter();
+        exception.printStackTrace(new PrintWriter(stringWriter));
+        return stringWriter.toString();
+    }
+}

--- a/src/main/java/corecord/dev/common/log/discord/dto/DiscordDto.java
+++ b/src/main/java/corecord/dev/common/log/discord/dto/DiscordDto.java
@@ -1,0 +1,35 @@
+package corecord.dev.common.log.discord.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class DiscordDto {
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class MessageDto {
+        @JsonProperty("content")
+        private String content;
+
+        @JsonProperty("embeds")
+        private List<EmbedDto> embeds;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class EmbedDto {
+        @JsonProperty("title")
+        private String title;
+
+        @JsonProperty("description")
+        private String description;
+    }
+}

--- a/src/main/java/corecord/dev/domain/ability/exception/AbilityException.java
+++ b/src/main/java/corecord/dev/domain/ability/exception/AbilityException.java
@@ -1,17 +1,18 @@
 package corecord.dev.domain.ability.exception;
 
-import corecord.dev.domain.ability.status.AbilityErrorStatus;
-import lombok.AllArgsConstructor;
+import corecord.dev.common.base.BaseErrorStatus;
+import corecord.dev.common.exception.GeneralException;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
-public class AbilityException extends RuntimeException {
+public class AbilityException extends GeneralException {
 
-    private final AbilityErrorStatus abilityErrorStatus;
+    public AbilityException(BaseErrorStatus errorStatus) {
+        super(errorStatus);
+    }
 
     @Override
     public String getMessage() {
-        return abilityErrorStatus.getMessage();
+        return errorStatus.getMessage();
     }
 }

--- a/src/main/java/corecord/dev/domain/analysis/exception/AnalysisException.java
+++ b/src/main/java/corecord/dev/domain/analysis/exception/AnalysisException.java
@@ -1,16 +1,18 @@
 package corecord.dev.domain.analysis.exception;
 
-import corecord.dev.domain.analysis.status.AnalysisErrorStatus;
-import lombok.AllArgsConstructor;
+import corecord.dev.common.base.BaseErrorStatus;
+import corecord.dev.common.exception.GeneralException;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
-public class AnalysisException extends RuntimeException {
-    private final AnalysisErrorStatus analysisErrorStatus;
+public class AnalysisException extends GeneralException {
+
+    public AnalysisException(BaseErrorStatus errorStatus) {
+        super(errorStatus);
+    }
 
     @Override
     public String getMessage() {
-        return analysisErrorStatus.getMessage();
+        return errorStatus.getMessage();
     }
 }

--- a/src/main/java/corecord/dev/domain/analysis/status/AnalysisErrorStatus.java
+++ b/src/main/java/corecord/dev/domain/analysis/status/AnalysisErrorStatus.java
@@ -9,8 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AnalysisErrorStatus implements BaseErrorStatus {
     OVERFLOW_ANALYSIS_CONTENT(HttpStatus.BAD_REQUEST, "E0400_OVERFLOW_CONTENT", "경험 기록 내용은 500자 이내여야 합니다."),
-    OVERFLOW_ANALYSIS_COMMENT(HttpStatus.INTERNAL_SERVER_ERROR, "E0500_OVERFLOW_COMMENT", "경험 기록 코멘트는 200자 이내여야 합니다."),
-    OVERFLOW_ANALYSIS_KEYWORD_CONTENT(HttpStatus.INTERNAL_SERVER_ERROR, "E0500_OVERFLOW_KEYWORD_CONTENT", "경험 기록 키워드별 내용은 200자 이내여야 합니다."),
+    OVERFLOW_ANALYSIS_COMMENT(HttpStatus.BAD_REQUEST, "E0400_OVERFLOW_COMMENT", "경험 기록 코멘트는 200자 이내여야 합니다."),
+    OVERFLOW_ANALYSIS_KEYWORD_CONTENT(HttpStatus.BAD_REQUEST, "E0400_OVERFLOW_KEYWORD_CONTENT", "경험 기록 키워드별 내용은 200자 이내여야 합니다."),
     USER_ANALYSIS_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E401_ANALYSIS_UNAUTHORIZED", "유저가 역량 분석에 대한 권한이 없습니다."),
     ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "E0404_ANALYSIS", "존재하지 않는 역량 분석입니다."),
     INVALID_ABILITY_ANALYSIS(HttpStatus.INTERNAL_SERVER_ERROR, "E500_INVALID_ANALYSIS", "역량 분석 데이터 파싱 중 오류가 발생했습니다."),

--- a/src/main/java/corecord/dev/domain/auth/exception/TokenException.java
+++ b/src/main/java/corecord/dev/domain/auth/exception/TokenException.java
@@ -1,16 +1,18 @@
 package corecord.dev.domain.auth.exception;
 
-import corecord.dev.domain.auth.status.TokenErrorStatus;
+import corecord.dev.common.base.BaseErrorStatus;
+import corecord.dev.common.exception.GeneralException;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
-public class TokenException extends RuntimeException {
-    private final TokenErrorStatus tokenErrorStatus;
+public class TokenException extends GeneralException {
+
+    public TokenException(BaseErrorStatus errorStatus) {
+        super(errorStatus);
+    }
 
     @Override
     public String getMessage() {
-        return tokenErrorStatus.getMessage();
+        return errorStatus.getMessage();
     }
 }

--- a/src/main/java/corecord/dev/domain/auth/jwt/JwtFilter.java
+++ b/src/main/java/corecord/dev/domain/auth/jwt/JwtFilter.java
@@ -57,7 +57,7 @@ public class JwtFilter extends OncePerRequestFilter {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        String jsonResponse = String.format("{\"isSuccess\": \"false\", \"code\": \"%s\", \"message\": \"%s\"}", e.getTokenErrorStatus().getCode(), e.getMessage());
+        String jsonResponse = String.format("{\"isSuccess\": \"false\", \"code\": \"%s\", \"message\": \"%s\"}", e.getErrorStatus().getCode(), e.getMessage());
         response.getWriter().write(jsonResponse);
     }
 

--- a/src/main/java/corecord/dev/domain/chat/exception/ChatException.java
+++ b/src/main/java/corecord/dev/domain/chat/exception/ChatException.java
@@ -1,16 +1,20 @@
 package corecord.dev.domain.chat.exception;
 
+import corecord.dev.common.base.BaseErrorStatus;
+import corecord.dev.common.exception.GeneralException;
 import corecord.dev.domain.chat.status.ChatErrorStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
-public class ChatException extends RuntimeException {
-    private final ChatErrorStatus chatErrorStatus;
+public class ChatException extends GeneralException {
+
+    public ChatException(BaseErrorStatus errorStatus) {
+        super(errorStatus);
+    }
 
     @Override
     public String getMessage() {
-        return chatErrorStatus.getMessage();
+        return errorStatus.getMessage();
     }
 }

--- a/src/main/java/corecord/dev/domain/folder/exception/FolderException.java
+++ b/src/main/java/corecord/dev/domain/folder/exception/FolderException.java
@@ -1,16 +1,18 @@
 package corecord.dev.domain.folder.exception;
 
-import corecord.dev.domain.folder.status.FolderErrorStatus;
-import lombok.AllArgsConstructor;
+import corecord.dev.common.base.BaseErrorStatus;
+import corecord.dev.common.exception.GeneralException;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
-public class FolderException extends RuntimeException {
-    private final FolderErrorStatus folderErrorStatus;
+public class FolderException extends GeneralException {
+
+    public FolderException(BaseErrorStatus errorStatus) {
+        super(errorStatus);
+    }
 
     @Override
     public String getMessage() {
-        return folderErrorStatus.getMessage();
+        return errorStatus.getMessage();
     }
 }

--- a/src/main/java/corecord/dev/domain/record/exception/RecordException.java
+++ b/src/main/java/corecord/dev/domain/record/exception/RecordException.java
@@ -1,16 +1,18 @@
 package corecord.dev.domain.record.exception;
 
-import corecord.dev.domain.record.status.RecordErrorStatus;
-import lombok.AllArgsConstructor;
+import corecord.dev.common.base.BaseErrorStatus;
+import corecord.dev.common.exception.GeneralException;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
-public class RecordException extends RuntimeException {
-    private final RecordErrorStatus recordErrorStatus;
+public class RecordException extends GeneralException {
+
+    public RecordException(BaseErrorStatus errorStatus) {
+        super(errorStatus);
+    }
 
     @Override
     public String getMessage() {
-        return recordErrorStatus.getMessage();
+        return errorStatus.getMessage();
     }
 }

--- a/src/main/java/corecord/dev/domain/user/exception/UserException.java
+++ b/src/main/java/corecord/dev/domain/user/exception/UserException.java
@@ -1,16 +1,18 @@
 package corecord.dev.domain.user.exception;
 
-import corecord.dev.domain.user.status.UserErrorStatus;
+import corecord.dev.common.base.BaseErrorStatus;
+import corecord.dev.common.exception.GeneralException;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
-public class UserException extends RuntimeException {
-    private final UserErrorStatus userErrorStatus;
+public class UserException extends GeneralException {
+
+    public UserException(BaseErrorStatus errorStatus) {
+        super(errorStatus);
+    }
 
     @Override
     public String getMessage() {
-        return userErrorStatus.getMessage();
+        return errorStatus.getMessage();
     }
 }


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #4 

### 💡 작업내용
- Discord WebHook 연동
- 500에러 발생 시 알림 전송
- dev 서버의 예외만 잡도록 profile 설정
- Custom Exception RuntimeException 대신 GeneralException을 상속하도록 수정
- ExceptionAdvice GeneralException에 대해 일괄적으로 처리하도록 수정
- AOP `@Before`을 이용해 알림 전송하도록 수정
  - GeneralException이라면 500 status일 때만 알림 전송
  - 그 외에 발생한 Exception이라면 알림 전송 

### 📸 스크린샷(선택)
<img width="641" alt="스크린샷 2025-01-23 오후 6 10 42" src="https://github.com/user-attachments/assets/7a3c224d-dcba-4ccc-8b83-c66cb07b25bd" />


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
- 추후 Logback 이용해서 리팩토링 진행할 예정입니다
