### PR TITLE
[Refactor/#6] 성능 개선을 위한 인덱스 추가

### DIFF
--- a/src/main/java/corecord/dev/domain/ability/domain/entity/Ability.java
+++ b/src/main/java/corecord/dev/domain/ability/domain/entity/Ability.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "ability",
-        indexes = {@Index(name = "user_keyword_idx", columnList = "user_id, keyword")})
+        indexes = {@Index(name = "user_keyword_created_idx", columnList = "user_id, keyword, created_at")})
 public class Ability extends BaseEntity {
 
     @Id

--- a/src/main/java/corecord/dev/domain/ability/domain/entity/Ability.java
+++ b/src/main/java/corecord/dev/domain/ability/domain/entity/Ability.java
@@ -14,7 +14,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Table(name = "ability")
+@Table(name = "ability",
+        indexes = {@Index(name = "user_keyword_idx", columnList = "user_id, keyword")})
 public class Ability extends BaseEntity {
 
     @Id

--- a/src/main/java/corecord/dev/domain/analysis/domain/entity/Analysis.java
+++ b/src/main/java/corecord/dev/domain/analysis/domain/entity/Analysis.java
@@ -17,7 +17,8 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Table(name = "analysis")
+@Table(name = "analysis",
+        indexes = {@Index(name = "created_at_idx", columnList = "created_at")})
 public class Analysis extends BaseEntity {
 
     @Id

--- a/src/main/java/corecord/dev/domain/folder/domain/entity/Folder.java
+++ b/src/main/java/corecord/dev/domain/folder/domain/entity/Folder.java
@@ -16,7 +16,8 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Table(name = "folder")
+@Table(name = "folder",
+        indexes = {@Index(name = "user_created_at_idx", columnList = "user_id, created_at")})
 public class Folder extends BaseEntity {
 
     @Id

--- a/src/main/java/corecord/dev/domain/record/domain/entity/Record.java
+++ b/src/main/java/corecord/dev/domain/record/domain/entity/Record.java
@@ -15,7 +15,9 @@ import lombok.NoArgsConstructor;
 @Getter @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Table(name = "record")
+@Table(name = "record",
+        indexes = {@Index(name = "created_at_idx", columnList = "created_at"),
+        @Index(name = "user_created_at_idx", columnList = "user_id, created_at")})
 public class Record extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #6 

### 💡 작업내용
전반적으로 자주 함께 사용하는 칼럼들에 대해 복합 인덱스 생성했습니다
대다수의 API가 `created_at` col에 대해 `ORDER BY`를 수행하므로, 해당 col에 대한 복합 인덱스 생성했습니다 이에 따른 FileSorting 감소 및 조회에 대한 성능 향상 확인했습니다

- `Record` table
  - `created_at` col에 대한 인덱스 추가 
  - `user`, `created_at` col에 대한 복합 인덱스 추가 
- `Ability` table
  - `user_id`, `keyword`, `created_at` col에 대한 복합 인덱스 추가 
- `Analysis` table
  - `created_at` col에 대한 인덱스 추가 
- `Folder` table
  - `user`, `created_at` col에 대한 복합 인덱스 추가 


### 📸 스크린샷(선택)
- 하나의 예시에 대한 인덱스 추가 전후 EXPLAIN 쿼리 결과 첨부합니다

``` SQL
EXPLAIN SELECT distinct keyword AS keyword 
FROM ability a JOIN analysis ana 
WHERE a.user_id = ?
GROUP BY keyword 
ORDER BY COUNT(keyword) DESC, MAX(ana.created_at) DESC ;
```
<img width="1199" alt="1" src="https://github.com/user-attachments/assets/776a52b0-4128-4592-b216-bf54d1ddece0" />
<img width="1178" alt="2" src="https://github.com/user-attachments/assets/21e62570-f673-4d94-bce2-8cb085af535f" />



### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
- chat 도메인의 경우 이미 FK에 대한 인덱스를 잘 활용하고 있어 따로 새로운 인덱스를 추가하진 않았습니다
