### PR TITLE
[Refactor/#11] 역량 분석 기능 AI 연결 확장

### DIFF
--- a/src/main/java/corecord/dev/common/config/OpenAIConfig.java
+++ b/src/main/java/corecord/dev/common/config/OpenAIConfig.java
@@ -1,4 +1,4 @@
-package corecord.dev.domain.analysis.infra.openai.config;
+package corecord.dev.common.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/corecord/dev/common/config/SwaggerConfig.java
+++ b/src/main/java/corecord/dev/common/config/SwaggerConfig.java
@@ -12,8 +12,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
-        info = @Info(title = "CO:RECORD",
-                description = "Kusitms 30th CO:RECORD",
+        info = @Info(title = "MOAMOA",
+                description = "Kusitms 30th MOAMOA",
                 version = "v1"),
         servers = {
                 @Server(url = "https://api.moamoa.site",

--- a/src/main/java/corecord/dev/common/util/ClovaUtil.java
+++ b/src/main/java/corecord/dev/common/util/ClovaUtil.java
@@ -1,0 +1,66 @@
+package corecord.dev.common.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import corecord.dev.domain.chat.exception.ChatException;
+import corecord.dev.domain.chat.infra.clova.dto.request.ClovaRequest;
+import corecord.dev.domain.chat.status.ChatErrorStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class ClovaUtil {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final WebClient webClient = WebClient.create();
+
+    @Value("${ncp.chat.host}")
+    private String chatHost;
+
+    @Value("${ncp.chat.api-key}")
+    private String chatApiKey;
+
+    @Value("${ncp.chat.api-key-primary-val}")
+    private String chatApiKeyPrimaryVal;
+
+    @Value("${ncp.chat.request-id}")
+    private String chatRequestId;
+
+    public String postWebClient(ClovaRequest clovaRequest) {
+        return webClient.post()
+                .uri(chatHost)
+                .header("X-NCP-CLOVASTUDIO-API-KEY", chatApiKey)
+                .header("X-NCP-APIGW-API-KEY", chatApiKeyPrimaryVal)
+                .header("X-NCP-CLOVASTUDIO-REQUEST-ID", chatRequestId)
+                .header("Content-Type", "application/json; charset=utf-8")
+                .header("Accept", "application/json")
+                .bodyValue(clovaRequest)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> {
+                    log.error("클라이언트 오류 발생: 상태 코드 - {}", clientResponse.statusCode());
+                    return clientResponse.bodyToMono(String.class)
+                            .map(errorBody -> new ChatException(ChatErrorStatus.AI_CLIENT_ERROR));
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> {
+                    log.error("서버 오류 발생: 상태 코드 - {}", clientResponse.statusCode());
+                    return clientResponse.bodyToMono(String.class)
+                            .map(errorBody -> new ChatException(ChatErrorStatus.AI_SERVER_ERROR));
+                })
+                .bodyToMono(String.class)
+                .block();
+    }
+
+    public String parseContentFromResponse(String responseBody) {
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+            JsonNode messageContent = root.path("result").path("message").path("content");
+            return messageContent.asText();
+        } catch (Exception e) {
+            log.error("응답 파싱 실패", e);
+            throw new ChatException(ChatErrorStatus.INVALID_CHAT_RESPONSE);
+        }
+    }
+}

--- a/src/main/java/corecord/dev/common/util/ClovaUtil.java
+++ b/src/main/java/corecord/dev/common/util/ClovaUtil.java
@@ -3,7 +3,6 @@ package corecord.dev.common.util;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import corecord.dev.domain.chat.exception.ChatException;
-import corecord.dev.domain.chat.infra.clova.dto.request.ClovaRequest;
 import corecord.dev.domain.chat.status.ChatErrorStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,7 +28,7 @@ public class ClovaUtil {
     @Value("${ncp.chat.request-id}")
     private String chatRequestId;
 
-    public String postWebClient(ClovaRequest clovaRequest) {
+    public String postWebClient(Object clovaRequest) {
         return webClient.post()
                 .uri(chatHost)
                 .header("X-NCP-CLOVASTUDIO-API-KEY", chatApiKey)

--- a/src/main/java/corecord/dev/common/web/UserIdArgumentResolver.java
+++ b/src/main/java/corecord/dev/common/web/UserIdArgumentResolver.java
@@ -26,8 +26,7 @@ public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
         if (authentication == null) {
             throw new GeneralException(ErrorStatus.UNAUTHORIZED);
         } else {
-            Long userId = Long.valueOf(authentication.getPrincipal().toString());
-            return userId;
+            return Long.valueOf(authentication.getPrincipal().toString());
         }
     }
 }

--- a/src/main/java/corecord/dev/domain/analysis/application/AnalysisAIService.java
+++ b/src/main/java/corecord/dev/domain/analysis/application/AnalysisAIService.java
@@ -1,0 +1,8 @@
+package corecord.dev.domain.analysis.application;
+
+
+import corecord.dev.domain.analysis.infra.openai.dto.response.AnalysisAiResponse;
+
+public interface AnalysisAIService {
+    AnalysisAiResponse generateAbilityAnalysis(String content);
+}

--- a/src/main/java/corecord/dev/domain/analysis/application/AnalysisAIService.java
+++ b/src/main/java/corecord/dev/domain/analysis/application/AnalysisAIService.java
@@ -5,4 +5,5 @@ import corecord.dev.domain.analysis.infra.openai.dto.response.AnalysisAiResponse
 
 public interface AnalysisAIService {
     AnalysisAiResponse generateAbilityAnalysis(String content);
+    String generateMemoSummary(String content);
 }

--- a/src/main/java/corecord/dev/domain/analysis/application/AnalysisService.java
+++ b/src/main/java/corecord/dev/domain/analysis/application/AnalysisService.java
@@ -6,7 +6,6 @@ import corecord.dev.domain.analysis.domain.dto.request.AnalysisRequest;
 import corecord.dev.domain.analysis.infra.openai.dto.response.AnalysisAiResponse;
 import corecord.dev.domain.analysis.domain.dto.response.AnalysisResponse;
 import corecord.dev.domain.analysis.domain.entity.Analysis;
-import corecord.dev.domain.analysis.infra.openai.application.OpenAiAnalysisAIService;
 import corecord.dev.domain.analysis.status.AnalysisErrorStatus;
 import corecord.dev.domain.analysis.exception.AnalysisException;
 import corecord.dev.domain.record.application.RecordDbService;
@@ -24,7 +23,7 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class AnalysisService {
-    private final OpenAiAnalysisAIService openAiAnalysisAIService;
+    private final AnalysisAIService analysisAIService;
     private final AbilityService abilityService;
     private final AnalysisDbService analysisDbService;
     private final UserDbService userDbService;
@@ -167,7 +166,7 @@ public class AnalysisService {
     }
 
     private AnalysisAiResponse generateAbilityAnalysis(String content) {
-        AnalysisAiResponse response = openAiAnalysisAIService.generateAbilityAnalysis(content);
+        AnalysisAiResponse response = analysisAIService.generateAbilityAnalysis(content);
 
         // 글자 수 validation
         validAnalysisCommentLength(response.getComment());
@@ -201,7 +200,7 @@ public class AnalysisService {
     }
 
     private String generateMemoSummary(String content) {
-        String response = openAiAnalysisAIService.generateMemoSummary(content);
+        String response = analysisAIService.generateMemoSummary(content);
 
         validIsRecordEnough(response);
         validAnalysisContentLength(response);

--- a/src/main/java/corecord/dev/domain/analysis/application/AnalysisService.java
+++ b/src/main/java/corecord/dev/domain/analysis/application/AnalysisService.java
@@ -6,7 +6,7 @@ import corecord.dev.domain.analysis.domain.dto.request.AnalysisRequest;
 import corecord.dev.domain.analysis.infra.openai.dto.response.AnalysisAiResponse;
 import corecord.dev.domain.analysis.domain.dto.response.AnalysisResponse;
 import corecord.dev.domain.analysis.domain.entity.Analysis;
-import corecord.dev.domain.analysis.infra.openai.application.OpenAiService;
+import corecord.dev.domain.analysis.infra.openai.application.OpenAiAnalysisAIService;
 import corecord.dev.domain.analysis.status.AnalysisErrorStatus;
 import corecord.dev.domain.analysis.exception.AnalysisException;
 import corecord.dev.domain.record.application.RecordDbService;
@@ -24,7 +24,7 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class AnalysisService {
-    private final OpenAiService openAiService;
+    private final OpenAiAnalysisAIService openAiAnalysisAIService;
     private final AbilityService abilityService;
     private final AnalysisDbService analysisDbService;
     private final UserDbService userDbService;
@@ -167,7 +167,7 @@ public class AnalysisService {
     }
 
     private AnalysisAiResponse generateAbilityAnalysis(String content) {
-        AnalysisAiResponse response = openAiService.generateAbilityAnalysis(content);
+        AnalysisAiResponse response = openAiAnalysisAIService.generateAbilityAnalysis(content);
 
         // 글자 수 validation
         validAnalysisCommentLength(response.getComment());
@@ -201,7 +201,7 @@ public class AnalysisService {
     }
 
     private String generateMemoSummary(String content) {
-        String response = openAiService.generateMemoSummary(content);
+        String response = openAiAnalysisAIService.generateMemoSummary(content);
 
         validIsRecordEnough(response);
         validAnalysisContentLength(response);

--- a/src/main/java/corecord/dev/domain/analysis/infra/clova/application/ClovaAnalysisAIService.java
+++ b/src/main/java/corecord/dev/domain/analysis/infra/clova/application/ClovaAnalysisAIService.java
@@ -1,0 +1,11 @@
+package corecord.dev.domain.analysis.infra.clova.application;
+
+import corecord.dev.domain.analysis.application.AnalysisAIService;
+import corecord.dev.domain.analysis.infra.openai.dto.response.AnalysisAiResponse;
+
+public class ClovaAnalysisAIService implements AnalysisAIService {
+    @Override
+    public AnalysisAiResponse generateAbilityAnalysis(String content) {
+        return null;
+    }
+}

--- a/src/main/java/corecord/dev/domain/analysis/infra/clova/application/ClovaAnalysisAIService.java
+++ b/src/main/java/corecord/dev/domain/analysis/infra/clova/application/ClovaAnalysisAIService.java
@@ -2,10 +2,19 @@ package corecord.dev.domain.analysis.infra.clova.application;
 
 import corecord.dev.domain.analysis.application.AnalysisAIService;
 import corecord.dev.domain.analysis.infra.openai.dto.response.AnalysisAiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
+@Service
+@RequiredArgsConstructor
 public class ClovaAnalysisAIService implements AnalysisAIService {
     @Override
     public AnalysisAiResponse generateAbilityAnalysis(String content) {
         return null;
+    }
+
+    @Override
+    public String generateMemoSummary(String content) {
+        return "";
     }
 }

--- a/src/main/java/corecord/dev/domain/analysis/infra/clova/application/ClovaAnalysisAIService.java
+++ b/src/main/java/corecord/dev/domain/analysis/infra/clova/application/ClovaAnalysisAIService.java
@@ -1,20 +1,46 @@
 package corecord.dev.domain.analysis.infra.clova.application;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import corecord.dev.common.util.ClovaUtil;
 import corecord.dev.domain.analysis.application.AnalysisAIService;
+import corecord.dev.domain.analysis.exception.AnalysisException;
+import corecord.dev.domain.analysis.infra.clova.dto.request.ClovaAnalysisRequest;
 import corecord.dev.domain.analysis.infra.openai.dto.response.AnalysisAiResponse;
+import corecord.dev.domain.analysis.status.AnalysisErrorStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class ClovaAnalysisAIService implements AnalysisAIService {
+
+    private final ClovaUtil clovaUtil;
+
     @Override
     public AnalysisAiResponse generateAbilityAnalysis(String content) {
-        return null;
+        ClovaAnalysisRequest clovaRequest = ClovaAnalysisRequest.createAbilityAnalysisRequest(content);
+        String responseBody = clovaUtil.postWebClient(clovaRequest);
+        String aiResponse = clovaUtil.parseContentFromResponse(responseBody);
+
+        return parseAnalysisAiResponse(aiResponse);
     }
 
     @Override
     public String generateMemoSummary(String content) {
-        return "";
+        ClovaAnalysisRequest clovaRequest = ClovaAnalysisRequest.createMemoSummaryRequest(content);
+        String responseBody = clovaUtil.postWebClient(clovaRequest);
+        return clovaUtil.parseContentFromResponse(responseBody);
+    }
+
+    private AnalysisAiResponse parseAnalysisAiResponse(String aiResponse) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.readValue(aiResponse, AnalysisAiResponse.class);
+        } catch (JsonProcessingException e) {
+            throw new AnalysisException(AnalysisErrorStatus.INVALID_ABILITY_ANALYSIS);
+        }
     }
 }

--- a/src/main/java/corecord/dev/domain/analysis/infra/clova/dto/request/ClovaAnalysisRequest.java
+++ b/src/main/java/corecord/dev/domain/analysis/infra/clova/dto/request/ClovaAnalysisRequest.java
@@ -1,0 +1,44 @@
+package corecord.dev.domain.analysis.infra.clova.dto.request;
+
+import corecord.dev.common.util.ResourceLoader;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class ClovaAnalysisRequest {
+    private static final int MAX_TOKENS = 500;
+    private static final String ABILITY_ANALYSIS_SYSTEM_CONTENT = ResourceLoader.getResourceContent("ability-analysis-prompt.txt");
+    private static final String MEMO_SUMMARY_SYSTEM_CONTENT = ResourceLoader.getResourceContent("memo-summary-prompt.txt");
+
+    private List<Map<String, String>> messages;
+    private final double topP = 0.8;
+    private final int topK = 0;
+    private final int maxTokens;
+    private final double temperature = 0.5;
+    private final double repeatPenalty = 5.0;
+    private final boolean includeAiFilters = true;
+    private final int seed = 0;
+
+    public ClovaAnalysisRequest(List<Map<String, String>> messages, int max_tokens) {
+        this.messages = messages;
+        this.maxTokens = max_tokens;
+    }
+
+    public static ClovaAnalysisRequest createAbilityAnalysisRequest(String content) {
+        return createRequest(ABILITY_ANALYSIS_SYSTEM_CONTENT, content);
+    }
+
+    public static ClovaAnalysisRequest createMemoSummaryRequest(String content) {
+        return createRequest(MEMO_SUMMARY_SYSTEM_CONTENT, content);
+    }
+
+    public static ClovaAnalysisRequest createRequest(String systemContent, String userContent) {
+        List<Map<String, String>> messages = new ArrayList<>();
+        messages.add(Map.of("role", "system", "content", systemContent));
+        messages.add(Map.of("role", "user", "content", userContent));
+        return new ClovaAnalysisRequest(messages, MAX_TOKENS);
+    }
+}

--- a/src/main/java/corecord/dev/domain/analysis/infra/openai/application/OpenAiAnalysisAIService.java
+++ b/src/main/java/corecord/dev/domain/analysis/infra/openai/application/OpenAiAnalysisAIService.java
@@ -9,8 +9,10 @@ import corecord.dev.domain.analysis.status.AnalysisErrorStatus;
 import corecord.dev.domain.analysis.exception.AnalysisException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
+@Primary
 @Service
 @RequiredArgsConstructor
 public class OpenAiAnalysisAIService implements AnalysisAIService {
@@ -24,6 +26,7 @@ public class OpenAiAnalysisAIService implements AnalysisAIService {
         return parseAnalysisAiResponse(response);
     }
 
+    @Override
     public String generateMemoSummary(String content) {
         return chatModel.call(SUMMARY_SYSTEM_CONTENT + content);
     }

--- a/src/main/java/corecord/dev/domain/analysis/infra/openai/application/OpenAiAnalysisAIService.java
+++ b/src/main/java/corecord/dev/domain/analysis/infra/openai/application/OpenAiAnalysisAIService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import corecord.dev.common.util.ResourceLoader;
 import corecord.dev.domain.analysis.application.AnalysisAIService;
+import corecord.dev.domain.analysis.infra.clova.application.ClovaAnalysisAIService;
 import corecord.dev.domain.analysis.infra.openai.dto.response.AnalysisAiResponse;
 import corecord.dev.domain.analysis.status.AnalysisErrorStatus;
 import corecord.dev.domain.analysis.exception.AnalysisException;
@@ -11,24 +12,35 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpServerErrorException;
 
 @Primary
 @Service
 @RequiredArgsConstructor
 public class OpenAiAnalysisAIService implements AnalysisAIService {
     private final OpenAiChatModel chatModel;
+    private final ClovaAnalysisAIService clovaAnalysisAIService;
     private static final String ABILITY_ANALYSIS_SYSTEM_CONTENT = ResourceLoader.getResourceContent("ability-analysis-prompt.txt");
     private static final String SUMMARY_SYSTEM_CONTENT = ResourceLoader.getResourceContent("memo-summary-prompt.txt");
 
     @Override
     public AnalysisAiResponse generateAbilityAnalysis(String content) {
-        String response = chatModel.call(ABILITY_ANALYSIS_SYSTEM_CONTENT + content);
-        return parseAnalysisAiResponse(response);
+        String response;
+        try {
+            response = chatModel.call(ABILITY_ANALYSIS_SYSTEM_CONTENT + content);
+            return parseAnalysisAiResponse(response);
+        } catch (HttpServerErrorException e) {
+            return clovaAnalysisAIService.generateAbilityAnalysis(content);
+        }
     }
 
     @Override
     public String generateMemoSummary(String content) {
-        return chatModel.call(SUMMARY_SYSTEM_CONTENT + content);
+        try {
+            return chatModel.call(SUMMARY_SYSTEM_CONTENT + content);
+        } catch (HttpServerErrorException e) {
+            return clovaAnalysisAIService.generateMemoSummary(content);
+        }
     }
 
     private AnalysisAiResponse parseAnalysisAiResponse(String aiResponse) {

--- a/src/main/java/corecord/dev/domain/analysis/infra/openai/application/OpenAiAnalysisAIService.java
+++ b/src/main/java/corecord/dev/domain/analysis/infra/openai/application/OpenAiAnalysisAIService.java
@@ -3,6 +3,7 @@ package corecord.dev.domain.analysis.infra.openai.application;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import corecord.dev.common.util.ResourceLoader;
+import corecord.dev.domain.analysis.application.AnalysisAIService;
 import corecord.dev.domain.analysis.infra.openai.dto.response.AnalysisAiResponse;
 import corecord.dev.domain.analysis.status.AnalysisErrorStatus;
 import corecord.dev.domain.analysis.exception.AnalysisException;
@@ -12,11 +13,12 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class OpenAiService {
+public class OpenAiAnalysisAIService implements AnalysisAIService {
     private final OpenAiChatModel chatModel;
     private static final String ABILITY_ANALYSIS_SYSTEM_CONTENT = ResourceLoader.getResourceContent("ability-analysis-prompt.txt");
     private static final String SUMMARY_SYSTEM_CONTENT = ResourceLoader.getResourceContent("memo-summary-prompt.txt");
 
+    @Override
     public AnalysisAiResponse generateAbilityAnalysis(String content) {
         String response = chatModel.call(ABILITY_ANALYSIS_SYSTEM_CONTENT + content);
         return parseAnalysisAiResponse(response);

--- a/src/main/java/corecord/dev/domain/chat/infra/clova/application/ClovaChatAIService.java
+++ b/src/main/java/corecord/dev/domain/chat/infra/clova/application/ClovaChatAIService.java
@@ -3,8 +3,6 @@ package corecord.dev.domain.chat.infra.clova.application;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import corecord.dev.common.exception.GeneralException;
-import corecord.dev.common.status.ErrorStatus;
 import corecord.dev.domain.chat.application.ChatAIService;
 import corecord.dev.domain.chat.domain.entity.Chat;
 import corecord.dev.domain.chat.exception.ChatException;
@@ -24,7 +22,7 @@ import java.util.List;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class ClovaService implements ChatAIService {
+public class ClovaChatAIService implements ChatAIService {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final WebClient webClient = WebClient.create();

--- a/src/main/java/corecord/dev/domain/chat/infra/clova/application/ClovaChatAIService.java
+++ b/src/main/java/corecord/dev/domain/chat/infra/clova/application/ClovaChatAIService.java
@@ -1,8 +1,8 @@
 package corecord.dev.domain.chat.infra.clova.application;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import corecord.dev.common.util.ClovaUtil;
 import corecord.dev.domain.chat.application.ChatAIService;
 import corecord.dev.domain.chat.domain.entity.Chat;
 import corecord.dev.domain.chat.exception.ChatException;
@@ -11,10 +11,7 @@ import corecord.dev.domain.chat.domain.dto.response.ChatSummaryAiResponse;
 import corecord.dev.domain.chat.status.ChatErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientException;
 
 import java.util.List;
@@ -24,28 +21,15 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ClovaChatAIService implements ChatAIService {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-    private final WebClient webClient = WebClient.create();
-
-    @Value("${ncp.chat.host}")
-    private String chatHost;
-
-    @Value("${ncp.chat.api-key}")
-    private String chatApiKey;
-
-    @Value("${ncp.chat.api-key-primary-val}")
-    private String chatApiKeyPrimaryVal;
-
-    @Value("${ncp.chat.request-id}")
-    private String chatRequestId;
+    private final ClovaUtil clovaUtil;
 
     @Override
     public String generateChatResponse(List<Chat> chatHistory, String userInput) {
         try {
             ClovaRequest clovaRequest = ClovaRequest.createChatRequest(chatHistory, userInput);
-            String responseBody = postWebClient(clovaRequest);
+            String responseBody = clovaUtil.postWebClient(clovaRequest);
 
-            return parseContentFromResponse(responseBody);
+            return clovaUtil.parseContentFromResponse(responseBody);
         } catch (WebClientException e) {
             log.error("채팅 AI 응답 생성 실패", e);
             throw new ChatException(ChatErrorStatus.AI_RESPONSE_ERROR);
@@ -56,48 +40,13 @@ public class ClovaChatAIService implements ChatAIService {
     public ChatSummaryAiResponse generateChatSummaryResponse(List<Chat> chatHistory) {
         try {
             ClovaRequest clovaRequest = ClovaRequest.createChatSummaryRequest(chatHistory);
-            String responseBody = postWebClient(clovaRequest);
-            String aiResponse = parseContentFromResponse(responseBody);
+            String responseBody = clovaUtil.postWebClient(clovaRequest);
+            String aiResponse = clovaUtil.parseContentFromResponse(responseBody);
 
             return parseChatSummaryResponse(aiResponse);
         } catch (WebClientException e) {
             log.error("채팅 AI 응답 생성 실패", e);
             throw new ChatException(ChatErrorStatus.AI_RESPONSE_ERROR);
-        }
-    }
-
-    private String postWebClient(ClovaRequest clovaRequest) {
-        return webClient.post()
-                .uri(chatHost)
-                .header("X-NCP-CLOVASTUDIO-API-KEY", chatApiKey)
-                .header("X-NCP-APIGW-API-KEY", chatApiKeyPrimaryVal)
-                .header("X-NCP-CLOVASTUDIO-REQUEST-ID", chatRequestId)
-                .header("Content-Type", "application/json; charset=utf-8")
-                .header("Accept", "application/json")
-                .bodyValue(clovaRequest)
-                .retrieve()
-                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> {
-                    log.error("클라이언트 오류 발생: 상태 코드 - {}", clientResponse.statusCode());
-                    return clientResponse.bodyToMono(String.class)
-                            .map(errorBody -> new ChatException(ChatErrorStatus.AI_CLIENT_ERROR));
-                })
-                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> {
-                    log.error("서버 오류 발생: 상태 코드 - {}", clientResponse.statusCode());
-                    return clientResponse.bodyToMono(String.class)
-                            .map(errorBody -> new ChatException(ChatErrorStatus.AI_SERVER_ERROR));
-                })
-                .bodyToMono(String.class)
-                .block();
-    }
-
-    private String parseContentFromResponse(String responseBody) {
-        try {
-            JsonNode root = objectMapper.readTree(responseBody);
-            JsonNode messageContent = root.path("result").path("message").path("content");
-            return messageContent.asText();
-        } catch (Exception e) {
-            log.error("응답 파싱 실패", e);
-            throw new ChatException(ChatErrorStatus.INVALID_CHAT_RESPONSE);
         }
     }
 

--- a/src/main/java/corecord/dev/domain/chat/infra/clova/application/ClovaChatAIService.java
+++ b/src/main/java/corecord/dev/domain/chat/infra/clova/application/ClovaChatAIService.java
@@ -6,7 +6,7 @@ import corecord.dev.common.util.ClovaUtil;
 import corecord.dev.domain.chat.application.ChatAIService;
 import corecord.dev.domain.chat.domain.entity.Chat;
 import corecord.dev.domain.chat.exception.ChatException;
-import corecord.dev.domain.chat.infra.clova.dto.request.ClovaRequest;
+import corecord.dev.domain.chat.infra.clova.dto.request.ClovaChatRequest;
 import corecord.dev.domain.chat.domain.dto.response.ChatSummaryAiResponse;
 import corecord.dev.domain.chat.status.ChatErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -26,12 +26,12 @@ public class ClovaChatAIService implements ChatAIService {
     @Override
     public String generateChatResponse(List<Chat> chatHistory, String userInput) {
         try {
-            ClovaRequest clovaRequest = ClovaRequest.createChatRequest(chatHistory, userInput);
+            ClovaChatRequest clovaRequest = ClovaChatRequest.createChatRequest(chatHistory, userInput);
             String responseBody = clovaUtil.postWebClient(clovaRequest);
 
             return clovaUtil.parseContentFromResponse(responseBody);
         } catch (WebClientException e) {
-            log.error("채팅 AI 응답 생성 실패", e);
+            log.error("CLOVA 채팅 AI 응답 생성 실패", e);
             throw new ChatException(ChatErrorStatus.AI_RESPONSE_ERROR);
         }
     }
@@ -39,13 +39,13 @@ public class ClovaChatAIService implements ChatAIService {
     @Override
     public ChatSummaryAiResponse generateChatSummaryResponse(List<Chat> chatHistory) {
         try {
-            ClovaRequest clovaRequest = ClovaRequest.createChatSummaryRequest(chatHistory);
+            ClovaChatRequest clovaRequest = ClovaChatRequest.createChatSummaryRequest(chatHistory);
             String responseBody = clovaUtil.postWebClient(clovaRequest);
             String aiResponse = clovaUtil.parseContentFromResponse(responseBody);
 
             return parseChatSummaryResponse(aiResponse);
         } catch (WebClientException e) {
-            log.error("채팅 AI 응답 생성 실패", e);
+            log.error("CLOVA 채팅 AI 응답 생성 실패", e);
             throw new ChatException(ChatErrorStatus.AI_RESPONSE_ERROR);
         }
     }

--- a/src/main/java/corecord/dev/domain/chat/infra/clova/dto/request/ClovaChatRequest.java
+++ b/src/main/java/corecord/dev/domain/chat/infra/clova/dto/request/ClovaChatRequest.java
@@ -9,10 +9,9 @@ import java.util.List;
 import java.util.Map;
 
 @Getter
-public class ClovaRequest {
+public class ClovaChatRequest {
     private static final int CHAT_MAX_TOKENS = 256;
     private static final int SUMMARY_MAX_TOKENS = 500;
-    private static final int ABILITY_ANALYSIS_MAX_TOKENS = 500;
     private static final String CHAT_SYSTEM_CONTENT = ResourceLoader.getResourceContent("chat-prompt.txt");
     private static final String SUMMARY_SYSTEM_CONTENT = ResourceLoader.getResourceContent("chat-summary-prompt.txt");
 
@@ -25,19 +24,16 @@ public class ClovaRequest {
     private final boolean includeAiFilters = true;
     private final int seed = 0;
 
-    public ClovaRequest(List<Map<String, String>> messages, int max_tokens) {
+    public ClovaChatRequest(List<Map<String, String>> messages, int max_tokens) {
         this.messages = messages;
         this.maxTokens = max_tokens;
     }
 
-    public static ClovaRequest createChatRequest(List<Chat> chatHistory, String userContent) {
+    public static ClovaChatRequest createChatRequest(List<Chat> chatHistory, String userContent) {
         List<Map<String, String>> messages = new ArrayList<>();
 
         // 시스템 메시지 추가
-        messages.add(Map.of(
-                "role", "system",
-                "content", CHAT_SYSTEM_CONTENT
-        ));
+        messages.add(Map.of("role", "system", "content", CHAT_SYSTEM_CONTENT));
 
         // 기존 채팅 내역 추가
         for (Chat chat : chatHistory) {
@@ -48,17 +44,14 @@ public class ClovaRequest {
         // 사용자 입력 추가
         messages.add(Map.of("role", "user", "content", userContent));
 
-        return new ClovaRequest(messages, CHAT_MAX_TOKENS);
+        return new ClovaChatRequest(messages, CHAT_MAX_TOKENS);
     }
 
-    public static ClovaRequest createChatSummaryRequest(List<Chat> chatHistory) {
+    public static ClovaChatRequest createChatSummaryRequest(List<Chat> chatHistory) {
         List<Map<String, String>> messages = new ArrayList<>();
 
         // 시스템 메시지 추가
-        messages.add(Map.of(
-                "role", "system",
-                "content", SUMMARY_SYSTEM_CONTENT
-        ));
+        messages.add(Map.of("role", "system", "content", SUMMARY_SYSTEM_CONTENT));
 
         // 기존 채팅 내역을 하나의 문자열로 병합
         StringBuilder chatContentBuilder = new StringBuilder();
@@ -69,11 +62,8 @@ public class ClovaRequest {
         String chatContent = chatContentBuilder.toString();
 
         // 병합된 내용을 추가
-        messages.add(Map.of(
-                "role", "user",
-                "content", chatContent
-        ));
+        messages.add(Map.of("role", "user", "content", chatContent));
 
-        return new ClovaRequest(messages, SUMMARY_MAX_TOKENS);
+        return new ClovaChatRequest(messages, SUMMARY_MAX_TOKENS);
     }
 }

--- a/src/main/java/corecord/dev/domain/chat/infra/openai/application/OpenAiChatAIService.java
+++ b/src/main/java/corecord/dev/domain/chat/infra/openai/application/OpenAiChatAIService.java
@@ -22,7 +22,7 @@ import java.util.Map;
 @Primary
 @Service
 @RequiredArgsConstructor
-public class OpenAiChatService implements ChatAIService {
+public class OpenAiChatAIService implements ChatAIService {
     private final OpenAiChatModel chatModel;
     private final ClovaService clovaService;
     private static final String CHAT_SYSTEM_CONTENT = ResourceLoader.getResourceContent("chat-prompt.txt");

--- a/src/main/java/corecord/dev/domain/chat/infra/openai/application/OpenAiChatAIService.java
+++ b/src/main/java/corecord/dev/domain/chat/infra/openai/application/OpenAiChatAIService.java
@@ -33,16 +33,10 @@ public class OpenAiChatAIService implements ChatAIService {
         List<Map<String, String>> messages = new ArrayList<>();
 
         // 시스템 메시지 추가
-        messages.add(Map.of(
-                "role", "system",
-                "content", CHAT_SYSTEM_CONTENT
-        ));
+        addSystemMessage(messages, CHAT_SYSTEM_CONTENT);
 
         // 기존 채팅 내역 추가
-        for (Chat chat : chatHistory) {
-            String role = chat.getAuthor() == 0 ? "assistant" : "user";
-            messages.add(Map.of("role", role, "content", chat.getContent()));
-        }
+        addExistingChats(messages, chatHistory);
 
         // 사용자 입력 추가
         messages.add(Map.of("role", "user", "content", userContent));
@@ -59,16 +53,10 @@ public class OpenAiChatAIService implements ChatAIService {
         List<Map<String, String>> messages = new ArrayList<>();
 
         // 시스템 메시지 추가
-        messages.add(Map.of(
-                "role", "system",
-                "content", SUMMARY_SYSTEM_CONTENT
-        ));
+        addSystemMessage(messages, SUMMARY_SYSTEM_CONTENT);
 
         // 기존 채팅 내역 추가
-        for (Chat chat : chatHistory) {
-            String role = chat.getAuthor() == 0 ? "assistant" : "user";
-            messages.add(Map.of("role", role, "content", chat.getContent()));
-        }
+        addExistingChats(messages, chatHistory);
 
         String response;
         try {
@@ -80,6 +68,20 @@ public class OpenAiChatAIService implements ChatAIService {
         return parseChatSummaryResponse(response);
     }
 
+    private void addSystemMessage(List<Map<String, String>> messages, String systemContent) {
+        messages.add(Map.of(
+                "role", "system",
+                "content", systemContent
+        ));
+    }
+
+    private void addExistingChats(List<Map<String, String>> messages, List<Chat> chatHistory) {
+        for (Chat chat : chatHistory) {
+            String role = chat.getAuthor() == 0 ? "assistant" : "user";
+            messages.add(Map.of("role", role, "content", chat.getContent()));
+        }
+    }
+
     private ChatSummaryAiResponse parseChatSummaryResponse(String aiResponse) {
         ObjectMapper objectMapper = new ObjectMapper();
         try {
@@ -88,5 +90,4 @@ public class OpenAiChatAIService implements ChatAIService {
             throw new ChatException(ChatErrorStatus.INVALID_CHAT_SUMMARY);
         }
     }
-
 }

--- a/src/main/java/corecord/dev/domain/chat/infra/openai/application/OpenAiChatAIService.java
+++ b/src/main/java/corecord/dev/domain/chat/infra/openai/application/OpenAiChatAIService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpServerErrorException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -72,6 +73,7 @@ public class OpenAiChatAIService implements ChatAIService {
                 "role", "system",
                 "content", systemContent
         ));
+    }
 
     private void addExistingChats(List<Map<String, String>> messages, List<Chat> chatHistory) {
         for (Chat chat : chatHistory) {

--- a/src/main/java/corecord/dev/domain/chat/infra/openai/application/OpenAiChatAIService.java
+++ b/src/main/java/corecord/dev/domain/chat/infra/openai/application/OpenAiChatAIService.java
@@ -7,7 +7,7 @@ import corecord.dev.domain.chat.application.ChatAIService;
 import corecord.dev.domain.chat.domain.dto.response.ChatSummaryAiResponse;
 import corecord.dev.domain.chat.domain.entity.Chat;
 import corecord.dev.domain.chat.exception.ChatException;
-import corecord.dev.domain.chat.infra.clova.application.ClovaService;
+import corecord.dev.domain.chat.infra.clova.application.ClovaChatAIService;
 import corecord.dev.domain.chat.status.ChatErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.openai.OpenAiChatModel;
@@ -24,7 +24,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class OpenAiChatAIService implements ChatAIService {
     private final OpenAiChatModel chatModel;
-    private final ClovaService clovaService;
+    private final ClovaChatAIService clovaChatAIService;
     private static final String CHAT_SYSTEM_CONTENT = ResourceLoader.getResourceContent("chat-prompt.txt");
     private static final String SUMMARY_SYSTEM_CONTENT = ResourceLoader.getResourceContent("chat-summary-prompt.txt");
 
@@ -44,7 +44,7 @@ public class OpenAiChatAIService implements ChatAIService {
         try {
             return chatModel.call(String.valueOf(messages));
         } catch (HttpServerErrorException e) {
-            return clovaService.generateChatResponse(chatHistory, userContent);
+            return clovaChatAIService.generateChatResponse(chatHistory, userContent);
         }
     }
 
@@ -62,7 +62,7 @@ public class OpenAiChatAIService implements ChatAIService {
         try {
             response =  chatModel.call(String.valueOf(messages));
         } catch (HttpServerErrorException e) {
-            response = clovaService.generateChatSummaryResponse(chatHistory).getContent();
+            response = clovaChatAIService.generateChatSummaryResponse(chatHistory).getContent();
         }
 
         return parseChatSummaryResponse(response);

--- a/src/test/java/corecord/dev/ability/service/AbilityServiceTest.java
+++ b/src/test/java/corecord/dev/ability/service/AbilityServiceTest.java
@@ -115,7 +115,7 @@ public class AbilityServiceTest {
         // When & Then
         AbilityException exception = assertThrows(AbilityException.class,
                 () -> abilityService.parseAndSaveAbilities(keywordList, analysis, user));
-        assertEquals(exception.getAbilityErrorStatus(), AbilityErrorStatus.INVALID_ABILITY_KEYWORD);
+        assertEquals(exception.getErrorStatus(), AbilityErrorStatus.INVALID_ABILITY_KEYWORD);
     }
 
     @Test

--- a/src/test/java/corecord/dev/auth/util/JwtUtilTest.java
+++ b/src/test/java/corecord/dev/auth/util/JwtUtilTest.java
@@ -131,7 +131,7 @@ public class JwtUtilTest {
 
         // then
         TokenException exception = assertThrows(TokenException.class, () -> jwtUtil.isAccessTokenValid(expiredAccessToken));
-        assertThat(exception.getTokenErrorStatus()).isEqualTo(TokenErrorStatus.INVALID_ACCESS_TOKEN);
+        assertThat(exception.getErrorStatus()).isEqualTo(TokenErrorStatus.INVALID_ACCESS_TOKEN);
     }
 
 
@@ -143,6 +143,6 @@ public class JwtUtilTest {
 
         // then
         TokenException exception = assertThrows(TokenException.class, () -> jwtUtil.isAccessTokenValid(invalidToken));
-        assertThat(exception.getTokenErrorStatus()).isEqualTo(TokenErrorStatus.INVALID_ACCESS_TOKEN);
+        assertThat(exception.getErrorStatus()).isEqualTo(TokenErrorStatus.INVALID_ACCESS_TOKEN);
     }
 }

--- a/src/test/java/corecord/dev/chat/service/ChatServiceTest.java
+++ b/src/test/java/corecord/dev/chat/service/ChatServiceTest.java
@@ -9,8 +9,6 @@ import corecord.dev.domain.chat.domain.dto.response.ChatSummaryAiResponse;
 import corecord.dev.domain.chat.domain.entity.Chat;
 import corecord.dev.domain.chat.domain.entity.ChatRoom;
 import corecord.dev.domain.chat.exception.ChatException;
-import corecord.dev.domain.chat.infra.clova.application.ClovaService;
-import corecord.dev.domain.chat.infra.clova.dto.request.ClovaRequest;
 import corecord.dev.domain.user.application.UserDbService;
 import corecord.dev.domain.user.domain.entity.Status;
 import corecord.dev.domain.user.domain.entity.User;

--- a/src/test/java/corecord/dev/record/memo/service/MemoRecordServiceTest.java
+++ b/src/test/java/corecord/dev/record/memo/service/MemoRecordServiceTest.java
@@ -114,7 +114,7 @@ public class MemoRecordServiceTest {
 
         RecordException exception = assertThrows(RecordException.class,
                 () -> recordService.createMemoRecord(1L, request));
-        assertEquals(exception.getRecordErrorStatus(), RecordErrorStatus.OVERFLOW_MEMO_RECORD_TITLE);
+        assertEquals(exception.getErrorStatus(), RecordErrorStatus.OVERFLOW_MEMO_RECORD_TITLE);
     }
 
     @Test
@@ -134,7 +134,7 @@ public class MemoRecordServiceTest {
 
         RecordException exception = assertThrows(RecordException.class,
                 () -> recordService.createMemoRecord(1L, request));
-        assertEquals(exception.getRecordErrorStatus(), RecordErrorStatus.NOT_ENOUGH_MEMO_RECORD_CONTENT);
+        assertEquals(exception.getErrorStatus(), RecordErrorStatus.NOT_ENOUGH_MEMO_RECORD_CONTENT);
     }
 
     @Test
@@ -174,7 +174,7 @@ public class MemoRecordServiceTest {
 
         RecordException exception = assertThrows(RecordException.class,
                 () -> recordService.createTmpMemoRecord(1L, request));
-        assertEquals(exception.getRecordErrorStatus(), RecordErrorStatus.ALREADY_TMP_MEMO);
+        assertEquals(exception.getErrorStatus(), RecordErrorStatus.ALREADY_TMP_MEMO);
 
         verify(userDbService, times(1)).findUserById(1L);
         verify(recordDbService, times(0)).saveRecord(any(Record.class));

--- a/src/test/java/corecord/dev/user/service/UserServiceTest.java
+++ b/src/test/java/corecord/dev/user/service/UserServiceTest.java
@@ -125,7 +125,7 @@ public class UserServiceTest {
         // When & Then
         UserException exception = Assertions.assertThrows(UserException.class,
                 () -> userService.registerUser(REGISTER_TOKEN, userRegisterDto));
-        assertThat(exception.getUserErrorStatus()).isEqualTo(UserErrorStatus.INVALID_USER_NICKNAME);
+        assertThat(exception.getErrorStatus()).isEqualTo(UserErrorStatus.INVALID_USER_NICKNAME);
     }
 
     @Test
@@ -142,7 +142,7 @@ public class UserServiceTest {
         // When & Then
         UserException exception = Assertions.assertThrows(UserException.class,
                 () -> userService.registerUser(REGISTER_TOKEN, userRegisterDto));
-        assertThat(exception.getUserErrorStatus()).isEqualTo(UserErrorStatus.INVALID_USER_NICKNAME);
+        assertThat(exception.getErrorStatus()).isEqualTo(UserErrorStatus.INVALID_USER_NICKNAME);
     }
 
     private User createTestUser() {


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #11 

### 💡 작업내용
- AI를 이용한 역량 분석 및 메모 요약 기능 OPENAI에 이어 CLOVA AI 모델 연결
  - 인터페이스 생성
  - OpenAi 연결하는 서비스 + Clova 연결하는 서비스 분리
  - `ClovaAnalysisRequest` / `ClovaAnalysisAIService` 생성
- CLOVA Util 생성
  - POST 요청을 보내고 결과 값을 String으로 파싱하는 코드 함유
-  OpenAi / Clova 이용하는 파일 명 분리
   - `[AI이름] + [도메인] + AI + Service`
   - `[AI이름] + [도메인] + Request `
- 역량 분석 중 OpenaI 서버 문제 발생 시 Clova 연결 

### 📸 스크린샷(선택)

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
- Clova Util 파일 위치가 고민됩니다
- Clova 이용을 위한 Request 파일 중복을 줄이고 싶습니다 ..
  - max_token / temparature같은 요소들을 공통으로 몰고 상속해서 사용하는 건 어떨까 고민 즁 
- `OpenAiConfig` 파일 위치 고민됩니다
  - chat + analysis 둘 다 openai를 사용하게 되었으니 common으로 옮겨야 하는가 싶습니다 
