### PR TITLE
[Chore/#18] 경험 기록 리스트 조회 API response dto 수정

### DIFF
--- a/src/main/java/corecord/dev/domain/record/application/RecordService.java
+++ b/src/main/java/corecord/dev/domain/record/application/RecordService.java
@@ -158,7 +158,7 @@ public class RecordService {
         if (hasNext)
             recordList = recordList.subList(0, listSize);
 
-        return RecordConverter.toRecordListDto(folderName, recordList, hasNext);
+        return RecordConverter.toRecordListDto(recordList, hasNext);
     }
 
     private List<Record> fetchRecords(User user, String folderName, Long lastRecordId) {
@@ -177,7 +177,7 @@ public class RecordService {
      * @return
      */
     @Transactional(readOnly = true)
-    public RecordResponse.KeywordRecordListDto getKeywordRecordList(Long userId, String keywordValue, Long lastRecordId) {
+    public RecordResponse.RecordListDto getKeywordRecordList(Long userId, String keywordValue, Long lastRecordId) {
         User user = userDbService.findUserById(userId);
 
         // 해당 keyword를 가진 ability 객체 조회 후 맵핑된 Record 객체 리스트 조회
@@ -189,7 +189,7 @@ public class RecordService {
         if (hasNext)
             recordList = recordList.subList(0, listSize);
 
-        return RecordConverter.toKeywordRecordListDto(recordList, hasNext);
+        return RecordConverter.toRecordListDto(recordList, hasNext);
     }
 
     private Keyword getKeyword(String keywordValue) {
@@ -222,7 +222,7 @@ public class RecordService {
         // 최근 생성된 3개의 데이터만 조회
         List<Record> recordList = recordDbService.findRecordListOrderByCreatedAt(user);
 
-        return RecordConverter.toRecordListDto("all", recordList, false);
+        return RecordConverter.toRecordListDto(recordList, false);
     }
 
     private void validTextLength(String title, String content) {

--- a/src/main/java/corecord/dev/domain/record/domain/converter/RecordConverter.java
+++ b/src/main/java/corecord/dev/domain/record/domain/converter/RecordConverter.java
@@ -75,39 +75,13 @@ public class RecordConverter {
                 .build();
     }
 
-    public static RecordResponse.RecordListDto toRecordListDto(String folder, List<Record> recordList, boolean hasNext) {
+    public static RecordResponse.RecordListDto toRecordListDto(List<Record> recordList, boolean hasNext) {
         List<RecordResponse.RecordDto> recordDtoList = recordList.stream()
                 .map(RecordConverter::toRecordDto)
                 .toList();
 
         return RecordResponse.RecordListDto.builder()
-                .folder(folder)
                 .recordDtoList(recordDtoList)
-                .hasNext(hasNext)
-                .build();
-    }
-
-    public static RecordResponse.KeywordRecordDto toKeywordRecordDto(Record record) {
-        String content = record.getContent();
-        String truncatedContent = content.length() > 30 ? content.substring(0, 30) : content;
-
-        return RecordResponse.KeywordRecordDto.builder()
-                .analysisId(record.getAnalysis().getAnalysisId())
-                .recordId(record.getRecordId())
-                .folder(record.getFolder().getTitle())
-                .title(record.getTitle())
-                .content(truncatedContent)
-                .createdAt(record.getCreatedAtFormatted())
-                .build();
-    }
-
-    public static RecordResponse.KeywordRecordListDto toKeywordRecordListDto(List<Record> recordList, boolean hasNext) {
-        List<RecordResponse.KeywordRecordDto> keywordRecordDtoList = recordList.stream()
-                .map(RecordConverter::toKeywordRecordDto)
-                .toList();
-
-        return RecordResponse.KeywordRecordListDto.builder()
-                .recordDtoList(keywordRecordDtoList)
                 .hasNext(hasNext)
                 .build();
     }

--- a/src/main/java/corecord/dev/domain/record/domain/dto/response/RecordResponse.java
+++ b/src/main/java/corecord/dev/domain/record/domain/dto/response/RecordResponse.java
@@ -48,30 +48,7 @@ public class RecordResponse {
     @AllArgsConstructor
     @Data
     public static class RecordListDto {
-        private String folder;
         private List<RecordDto> recordDtoList;
-        private boolean hasNext;
-    }
-
-    @Builder
-    @Getter
-    @AllArgsConstructor
-    @Data
-    public static class KeywordRecordDto {
-        private Long analysisId;
-        private Long recordId;
-        private String folder;
-        private String title;
-        private String content;
-        private String createdAt;
-    }
-
-    @Builder
-    @Getter
-    @AllArgsConstructor
-    @Data
-    public static class KeywordRecordListDto {
-        private List<KeywordRecordDto> recordDtoList;
         private boolean hasNext;
     }
 }

--- a/src/main/java/corecord/dev/domain/record/presentation/RecordController.java
+++ b/src/main/java/corecord/dev/domain/record/presentation/RecordController.java
@@ -63,12 +63,12 @@ public class RecordController {
     }
 
     @GetMapping("/keyword")
-    public ResponseEntity<ApiResponse<RecordResponse.KeywordRecordListDto>> getRecordListByKeyword(
+    public ResponseEntity<ApiResponse<RecordResponse.RecordListDto>> getRecordListByKeyword(
             @UserId Long userId,
             @RequestParam(name = "keyword") String keyword,
             @RequestParam(name = "lastRecordId", defaultValue = "0") Long lastRecordId
     ) {
-        RecordResponse.KeywordRecordListDto recordResponse = recordService.getKeywordRecordList(userId, keyword, lastRecordId);
+        RecordResponse.RecordListDto recordResponse = recordService.getKeywordRecordList(userId, keyword, lastRecordId);
         return ApiResponse.success(RecordSuccessStatus.KEYWORD_RECORD_LIST_GET_SUCCESS, recordResponse);
     }
 


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #18 

### 💡 작업내용
- keyword별 경험 기록 리스트 조회 API 와 폴더별 경험 기록 리스트 조회 API Response DTO 통일
  - 기존 keyword별 조회 response DTO 제거
  - `RecordResponse.RecordDto`, `RecordListDto` 일괄 사용
- 기존 `RecordListDto`에 있던 folderName field 제거했습니다  
  - 따라서 API `2.1` / `5.3` / `6.2` Response DTO 수정되었습니다 


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
