### PR TITLE
[Chore/#23] 경험 기록 API Response DTO 수정 및 Analysis-Ability FETCH TYPE 변경

### DIFF
--- a/src/main/java/corecord/dev/domain/ability/application/AbilityServiceImpl.java
+++ b/src/main/java/corecord/dev/domain/ability/application/AbilityServiceImpl.java
@@ -71,9 +71,8 @@ public class AbilityServiceImpl implements AbilityService {
 
             Ability ability = AbilityConverter.toAbility(keyword, entry.getValue(), analysis, user);
             abilityDbService.saveAbility(ability);
+            analysis.addAbility(ability);
 
-            if (analysis.getAbilityList() != null)
-                analysis.addAbility(ability);
             abilityCount++;
         }
         validAbilityCount(abilityCount);

--- a/src/main/java/corecord/dev/domain/analysis/domain/entity/Analysis.java
+++ b/src/main/java/corecord/dev/domain/analysis/domain/entity/Analysis.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -37,8 +38,8 @@ public class Analysis extends BaseEntity {
     private Record record;
 
     @BatchSize(size = 3)
-    @OneToMany(mappedBy = "analysis", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<Ability> abilityList;
+    @OneToMany(mappedBy = "analysis", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    private List<Ability> abilityList = new ArrayList<>();
 
     public void updateContent(String content) {
         if (content != null && !content.isEmpty())
@@ -52,9 +53,11 @@ public class Analysis extends BaseEntity {
     }
 
     public void addAbility(Ability ability) {
+        if (abilityList == null)
+            abilityList = new ArrayList<>();
+
         if (ability != null) {
             this.abilityList.add(ability);
         }
     }
-
 }

--- a/src/main/java/corecord/dev/domain/record/application/RecordDbService.java
+++ b/src/main/java/corecord/dev/domain/record/application/RecordDbService.java
@@ -43,8 +43,12 @@ public class RecordDbService {
         recordRepository.deleteRecordByFolder(folder);
     }
 
-    public int getRecordCount(User user) {
-        return recordRepository.getRecordCount(user);
+    public int getRecordCount(Long userId) {
+        return recordRepository.getRecordCount(userId);
+    }
+
+    public int getRecordCountByChatType(Long userId) {
+        return recordRepository.getRecordCountByType(userId);
     }
 
     @Transactional

--- a/src/main/java/corecord/dev/domain/record/application/RecordService.java
+++ b/src/main/java/corecord/dev/domain/record/application/RecordService.java
@@ -7,7 +7,7 @@ import corecord.dev.domain.record.domain.dto.response.RecordResponse;
 public interface RecordService {
 
     // record
-    RecordResponse.MemoRecordDto createMemoRecord(Long userId, RecordRequest.RecordDto recordDto);
+    RecordResponse.RecordAnalysisDto createRecord(Long userId, RecordRequest.RecordDto recordDto);
     RecordResponse.MemoRecordDto getMemoRecordDetail(Long userId, Long recordId);
 
     // tmp record

--- a/src/main/java/corecord/dev/domain/record/domain/converter/RecordConverter.java
+++ b/src/main/java/corecord/dev/domain/record/domain/converter/RecordConverter.java
@@ -2,6 +2,8 @@ package corecord.dev.domain.record.domain.converter;
 
 import corecord.dev.domain.ability.domain.enums.Keyword;
 import corecord.dev.domain.ability.domain.entity.Ability;
+import corecord.dev.domain.analysis.domain.converter.AnalysisConverter;
+import corecord.dev.domain.analysis.domain.entity.Analysis;
 import corecord.dev.domain.chat.domain.entity.ChatRoom;
 import corecord.dev.domain.folder.domain.entity.Folder;
 import corecord.dev.domain.record.domain.enums.RecordType;
@@ -56,6 +58,13 @@ public class RecordConverter {
                 .isExist(false)
                 .title(null)
                 .content(null)
+                .build();
+    }
+
+    public static RecordResponse.RecordAnalysisDto toRecordAnalysisDto(Analysis analysis, int chatRecordCount) {
+        return RecordResponse.RecordAnalysisDto.builder()
+                .analysisDto(AnalysisConverter.toAnalysisDto(analysis))
+                .chatRecordCount(chatRecordCount)
                 .build();
     }
 

--- a/src/main/java/corecord/dev/domain/record/domain/dto/response/RecordResponse.java
+++ b/src/main/java/corecord/dev/domain/record/domain/dto/response/RecordResponse.java
@@ -1,5 +1,6 @@
 package corecord.dev.domain.record.domain.dto.response;
 
+import corecord.dev.domain.analysis.domain.dto.response.AnalysisResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,6 +29,15 @@ public class RecordResponse {
         private Boolean isExist;
         private String title;
         private String content;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @Data
+    public static class RecordAnalysisDto {
+        private AnalysisResponse.AnalysisDto analysisDto;
+        private int chatRecordCount;
     }
 
     @Builder

--- a/src/main/java/corecord/dev/domain/record/domain/repository/RecordRepository.java
+++ b/src/main/java/corecord/dev/domain/record/domain/repository/RecordRepository.java
@@ -69,9 +69,16 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 
     @Query("SELECT COUNT(r) " +
             "FROM Record r " +
-            "WHERE r.user = :user " +
+            "WHERE r.user.userId = :userId " +
             "AND r.folder is not null") // 임시 저장 기록 제외
-    int getRecordCount(@Param(value = "user") User user);
+    int getRecordCount(@Param(value = "userId") Long userId);
+
+    @Query("SELECT COUNT(r) " +
+            "FROM Record r " +
+            "WHERE r.user.userId = :userId " +
+            "AND r.folder is not null " +
+            "AND r.type = 'CHAT' ")
+    int getRecordCountByType(@Param(value = "userId") Long userId);
 
     @Modifying
     @Query("DELETE " +

--- a/src/main/java/corecord/dev/domain/record/presentation/RecordController.java
+++ b/src/main/java/corecord/dev/domain/record/presentation/RecordController.java
@@ -18,12 +18,12 @@ public class RecordController {
     private final RecordService recordService;
 
     @PostMapping("")
-    public ResponseEntity<ApiResponse<RecordResponse.MemoRecordDto>> createMemoRecord(
+    public ResponseEntity<ApiResponse<RecordResponse.RecordAnalysisDto>> createRecord(
             @UserId Long userId,
             @RequestBody RecordRequest.RecordDto recordDto
     ) {
-        RecordResponse.MemoRecordDto recordResponse = recordService.createMemoRecord(userId, recordDto);
-        return ApiResponse.success(RecordSuccessStatus.MEMO_RECORD_CREATE_SUCCESS, recordResponse);
+        RecordResponse.RecordAnalysisDto recordResponse = recordService.createRecord(userId, recordDto);
+        return ApiResponse.success(RecordSuccessStatus.RECORD_CREATE_SUCCESS, recordResponse);
     }
 
     @GetMapping("/memo/{recordId}")

--- a/src/main/java/corecord/dev/domain/record/status/RecordSuccessStatus.java
+++ b/src/main/java/corecord/dev/domain/record/status/RecordSuccessStatus.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum RecordSuccessStatus implements BaseSuccessStatus {
 
-    MEMO_RECORD_CREATE_SUCCESS(HttpStatus.CREATED, "S404", "경험 기록이 성공적으로 완료되었습니다."),
+    RECORD_CREATE_SUCCESS(HttpStatus.CREATED, "S404", "경험 기록이 성공적으로 완료되었습니다."),
     MEMO_RECORD_DETAIL_GET_SUCCESS(HttpStatus.OK, "S401", "메모 경험 기록 세부 조회가 성공적으로 완료되었습니다."),
     MEMO_RECORD_TMP_CREATE_SUCCESS(HttpStatus.OK, "S403", "메모 경험 기록 임시 저장이 성공적으로 완료되었습니다."),
     MEMO_RECORD_TMP_GET_SUCCESS(HttpStatus.OK, "S402", "메모 경험 기록 임시 저장 내역 조회가 성공적으로 완료되었습니다."),

--- a/src/main/java/corecord/dev/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/corecord/dev/domain/user/application/UserServiceImpl.java
@@ -166,7 +166,7 @@ public class UserServiceImpl implements UserService {
     public UserResponse.UserInfoDto getUserInfo(Long userId) {
         User user = userDbService.getUser(userId);
 
-        int recordCount = recordDbService.getRecordCount(user);;
+        int recordCount = recordDbService.getRecordCount(user.getUserId());;
         return UserConverter.toUserInfoDto(user, recordCount);
     }
 

--- a/src/test/java/corecord/dev/user/service/UserServiceTest.java
+++ b/src/test/java/corecord/dev/user/service/UserServiceTest.java
@@ -82,7 +82,7 @@ public class UserServiceTest {
     void getUserInfo() {
         // Given
         when(userDbService.getUser(newUser.getUserId())).thenReturn(newUser);
-        when(recordDbService.getRecordCount(newUser)).thenReturn(0);
+        when(recordDbService.getRecordCount(newUser.getUserId())).thenReturn(0);
 
         // When
         UserResponse.UserInfoDto userInfoDto = userService.getUserInfo(newUser.getUserId());


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #23 

### 💡 작업내용
- 경험 기록 완료 시 반환하는 Response DTO 수정했습니다.
  - 기존 : record 상세 정보
  - 변경 : user의 CHAT type record 개수 + analysis 상세 정보
  - `RecordResponse.RecordAnalysisDto` 생성해 반환하도록 수정했습니다. 
- 경험 기록 이후 유저의 chat type Record 개수 카운팅
  - `CHAT` type일 때만 개수를 카운팅하고, `MEMO` type일 경우 0을 반환하도록 구현했습니다. 
- `Analysis` - `Ability` fetch type 변경
  - `LAZY` type에서 `EAGER` type으로 변경했습니다. 
  - 변경한 이유는 다음과 같습니다!
    1. 거의 모든 API에서 analysis를 조회할 때 ability도 함께 조회함
    2. analysis 객체 한 개 당 연결된 ability 객체는 최대 3개이기 때문에 부하 염려 X
    3. analysis, record 객체 생성 및 수정 후 **바로** ability 객체를 조회하는 경우가 많기 때문에 EAGER type으로 변경해도 문제가 없다고 판단
- `Analysis` : `addAbilityList()` 로직 수정
  - 기존: `analysis.getAbilityList != null`이면 함수 호출해 ability 객체 추가
  - 변경: Analysis 내부에서 `abilityList == null` 이면 list 생성 후 ability 객체 추가


### 📸 스크린샷(선택)
<img width="906" alt="스크린샷 2025-02-18 오후 8 42 20" src="https://github.com/user-attachments/assets/aa5ea5a5-b20c-47e0-89d1-8c6770de8a3b" />


### 📝 기타
새롭게 추가한 dto 네이밍과 파일 위치가 적절한지 의견 부탁드립니다 ! 
  1. `record` / `analysis` domain 중 어디에 속하는게 나을지
     - 전 record post 이후 반환되는 데이터이기 때문에 analysis 정보를 많이 포함하고 있더라도 record domain에 속하는게 적절하다고 생각하는데, 이에 대한 의견이 궁금합니다 
  4. dto naming 
  5. dto field
    - analysis 상세 정보 + chatRecordCount 정보가 필드를 이루기 때문에 기존 존재하던 analysisDto를 활용했습니다.
    - 따라서 `AnalysisConverter`가 `RecordConverter`에 등장하게 되고, response 값이 기존 analysis 상세 조회 API 의 응답 필드보다 depth가 한 층 생긴 상황입니다.
    - analysis dto를 활용하는게 좋을지, 혹은 중복 코드를 감안하더라도 필드를 새롭게 작성하는게 좋을지에 대한 의견이 궁금합니다

