### PR TITLE
[Feat/#29] : Test 서버 추가

### DIFF
--- a/.github/workflows/cicd-test.yml
+++ b/.github/workflows/cicd-test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: make application-secret.yml
         run: |
           touch ./src/main/resources/application-secret.yml
-          echo "${{ secrets.APPLICATION_SECRET }}" > ./src/main/resources/application-secret.yml
+          echo "${{ secrets.TEST_APPLICATION_SECRET }}" > ./src/main/resources/application-secret.yml
         shell: bash
 
       - name: make chat-prompt.txt

--- a/.github/workflows/cicd-test.yml
+++ b/.github/workflows/cicd-test.yml
@@ -1,0 +1,88 @@
+name: CD
+
+on:
+  push:
+    branches: [ "develop" ]
+
+jobs:
+  deploy-ci:
+    runs-on: ubuntu-22.04
+    env:
+      working-directory: moamoa
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '21'
+
+
+      - name: make application-secret.yml
+        run: |
+          touch ./src/main/resources/application-secret.yml
+          echo "${{ secrets.APPLICATION_SECRET }}" > ./src/main/resources/application-secret.yml
+        shell: bash
+
+      - name: make chat-prompt.txt
+        run: |
+          touch ./src/main/resources/chat-prompt.txt
+          echo "${{ secrets.CHAT_PROMPT }}" > ./src/main/resources/chat-prompt.txt
+        shell: bash
+
+      - name: make chat-summary-prompt.txt
+        run: |
+          cat <<EOF > ./src/main/resources/chat-summary-prompt.txt
+          ${{ secrets.CHAT_SUMMARY_PROMPT }}
+          EOF
+        shell: bash
+
+      - name: make memo-summary-prompt.txt
+        run: |
+          touch ./src/main/resources/memo-summary-prompt.txt
+          echo "${{ secrets.MEMO_SUMMARY_PROMPT }}" > ./src/main/resources/memo-summary-prompt.txt
+        shell: bash
+
+      - name: make ability-analysis-prompt.txt
+        run: |
+          cat <<EOF > ./src/main/resources/ability-analysis-prompt.txt
+          ${{ secrets.ABILITY_ANALYSIS_PROMPT }}
+          EOF
+        shell: bash
+
+
+      - name: 빌드
+        run: |
+          chmod +x gradlew
+          ./gradlew build -x test
+        shell: bash
+
+      - name: docker build 가능하도록 환경 설정
+        uses: docker/setup-buildx-action@v2.9.1
+
+      - name: docker hub에로그인
+        uses: docker/login-action@v2.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_LOGIN_ACCESSTOKEN }}
+
+      - name: docker image 빌드 및 푸시
+        run: |
+          docker build --platform linux/amd64 -t ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}/${{ secrets.DOCKERHUB_LOGIN_USERNAME }}:test .
+          docker push ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}/${{ secrets.DOCKERHUB_LOGIN_USERNAME }}:test
+
+  deploy-cd:
+    needs: deploy-ci
+    runs-on: ubuntu-22.04
+    steps:
+      - name: 도커 컨테이너 실행
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.TEST_RELEASE_HOST }}
+          username: ${{ secrets.TEST_RELEASE_USERNAME }}
+          key: ${{ secrets.TEST_RELEASE_KEY }}
+          script: |
+            sudo chmod +x /home/ubuntu/deploy.sh
+            sudo /home/ubuntu/deploy.sh

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,7 +2,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "main" ]
 
 jobs:
   deploy:


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #29 

### 💡 작업내용
- EC2 생성, nginx로 블루/그린 무중단배포 설정, certbot으로 https 설정
- test 서버는 develop 브랜치에 push할 경우 배포
- 실제 release 서버는 main 브랜치에 push 할 경우 배포
- cicd-test.yml 추가 및 기존 cicd.yml 브랜치 수정

### 📸 스크린샷(선택)

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
- 카카오 로그인 리다이렉트 url 때문에 test용 application-secret.yml을 git secret에 추가했습니다. (노션에 넣어두었습니다.)
- 배포 잘 되는지 테스트 필요합니다
