### PR TITLE
[Chore/#37] 예시 경험 폴더 조회 범위 수정

### DIFF
--- a/src/main/java/corecord/dev/domain/folder/application/FolderServiceImpl.java
+++ b/src/main/java/corecord/dev/domain/folder/application/FolderServiceImpl.java
@@ -119,7 +119,7 @@ public class FolderServiceImpl implements FolderService {
     @Override
     @Transactional
     public Folder createExampleFolder(User user) {
-        Folder folder = FolderConverter.toFolderEntity("MOAMOA", user);
+        Folder folder = FolderConverter.toFolderEntity("경험 기록 예시 폴더", user);
         folderDbService.saveFolder(folder);
         return folder;
     }

--- a/src/main/java/corecord/dev/domain/folder/domain/repository/FolderRepository.java
+++ b/src/main/java/corecord/dev/domain/folder/domain/repository/FolderRepository.java
@@ -18,6 +18,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     @Query("SELECT new corecord.dev.domain.folder.domain.dto.response.FolderResponse$FolderDto(f.folderId, f.title) " +
             "FROM Folder f " +
             "WHERE f.user.userId = :userId " +
+            "AND f.title <> '경험 기록 예시 폴더' " +
             "ORDER BY f.createdAt desc ")
     List<FolderResponse.FolderDto> findFolderDtoList(@Param(value = "userId") Long userId);
 

--- a/src/main/java/corecord/dev/domain/record/domain/repository/RecordRepository.java
+++ b/src/main/java/corecord/dev/domain/record/domain/repository/RecordRepository.java
@@ -25,7 +25,9 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             "JOIN r.user u " +
             "WHERE u.userId = :userId " +
             "AND (:last_record_id = 0 OR r.recordId < :last_record_id) " +  // 제일 마지막에 읽은 데이터 이후부터 가져옴
-            "AND r.folder is not null AND r.folder = :folder") // 임시 저장 기록 제외
+            "AND r.folder is not null " + // 임시 저장 기록 제외
+            "AND r.folder = :folder " +
+            "AND r.folder.title <> '경험 기록 예시 폴더'") // 예시 경험 기록 제외
     List<Record> findRecordsByFolder(
             @Param(value = "folder") Folder folder,
             @Param(value = "userId") Long userId,
@@ -39,7 +41,8 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             "JOIN r.user u " +
             "WHERE u.userId = :userId " +
             "AND (:last_record_id <= 0 OR r.recordId < :last_record_id) " + // 제일 마지막에 읽은 데이터 이후부터 가져옴
-            "AND r.folder is not null") // 임시 저장 기록 제외
+            "AND r.folder is not null " + // 임시 저장 기록 제외
+            "AND r.folder.title <> '경험 기록 예시 폴더'") // 예시 경험 기록 제외
     List<Record> findRecords(
             @Param(value = "userId") Long userId,
             @Param(value = "last_record_id") Long lastRecordId,


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #37 

### 💡 작업내용
- 회원가입 후 생성되는 예시용 폴더의 제목 변경
- 예시용 폴더의 조회 범위 수정
  - 기존 : 경험 모아보기 뷰에서 조회 가능
  - 변경 : 홈 화면(최근 생성)에서만 조회 가능


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
