### PR TITLE
[Fix/#44] : jwtFilter와 securityConfig에 OAuth url 제외 처리

### DIFF
--- a/src/main/java/corecord/dev/common/config/SecurityConfig.java
+++ b/src/main/java/corecord/dev/common/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
 
 
     private final String[] swaggerUrls = {"/swagger-ui/**", "/v3/**"};
-    private final String[] authUrls = {"/", "/api/users/register", "/oauth2/authorization/kakao", "/actuator/health", "/api/token/**", "/api/token"};
+    private final String[] authUrls = {"/", "/api/users/register", "/oauth2/authorization/kakao", "/actuator/health", "/api/token/**", "/api/token", "/login/oauth2/code/**"};
     private final String[] allowedUrls = Stream.concat(Arrays.stream(swaggerUrls), Arrays.stream(authUrls))
             .toArray(String[]::new);
 

--- a/src/main/java/corecord/dev/domain/auth/jwt/JwtFilter.java
+++ b/src/main/java/corecord/dev/domain/auth/jwt/JwtFilter.java
@@ -50,7 +50,7 @@ public class JwtFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         // 특정 경로는 필터링하지 않도록 설정
         String path = request.getRequestURI();
-        return path.startsWith("/oauth2/authorization/kakao") || path.startsWith("/api/users/register") || path.startsWith("/api/token") || path.startsWith("/actuator/health");
+        return path.startsWith("/oauth2/authorization/kakao") || path.startsWith("/api/users/register") || path.startsWith("/api/token") || path.startsWith("/actuator/health") || path.startsWith("/login/oauth2/code/**");
     }
 
     private void handleTokenException(HttpServletResponse response, TokenException e) throws IOException {


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #44 

### 💡 작업내용
- JWT 필터 (JwtFilter)에서 /login/oauth2/code/** URL을 예외 처리 (shouldNotFilter에 추가)
- SecurityConfig에서 OAuth2 URL (/login/oauth2/code/**) permitAll 처리

### 📸 스크린샷(선택)

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
