### PR TITLE
[Chore/#47] 역량 분석 AI 관련 에러 코드 수정

### DIFF
--- a/src/main/java/corecord/dev/domain/analysis/status/AnalysisErrorStatus.java
+++ b/src/main/java/corecord/dev/domain/analysis/status/AnalysisErrorStatus.java
@@ -9,8 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AnalysisErrorStatus implements BaseErrorStatus {
     OVERFLOW_ANALYSIS_CONTENT(HttpStatus.BAD_REQUEST, "E0400_OVERFLOW_CONTENT", "경험 기록 내용은 500자 이내여야 합니다."),
-    OVERFLOW_ANALYSIS_COMMENT(HttpStatus.BAD_REQUEST, "E0400_OVERFLOW_COMMENT", "경험 기록 코멘트는 200자 이내여야 합니다."),
-    OVERFLOW_ANALYSIS_KEYWORD_CONTENT(HttpStatus.BAD_REQUEST, "E0400_OVERFLOW_KEYWORD_CONTENT", "경험 기록 키워드별 내용은 200자 이내여야 합니다."),
+    OVERFLOW_ANALYSIS_COMMENT(HttpStatus.INTERNAL_SERVER_ERROR, "E0500_OVERFLOW_COMMENT", "경험 기록 코멘트는 200자 이내여야 합니다."),
+    OVERFLOW_ANALYSIS_KEYWORD_CONTENT(HttpStatus.INTERNAL_SERVER_ERROR, "E0500_OVERFLOW_KEYWORD_CONTENT", "경험 기록 키워드별 내용은 200자 이내여야 합니다."),
     USER_ANALYSIS_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E401_ANALYSIS_UNAUTHORIZED", "유저가 역량 분석에 대한 권한이 없습니다."),
     ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "E0404_ANALYSIS", "존재하지 않는 역량 분석입니다."),
     INVALID_ABILITY_ANALYSIS(HttpStatus.INTERNAL_SERVER_ERROR, "E500_INVALID_ANALYSIS", "역량 분석 데이터 파싱 중 오류가 발생했습니다."),

--- a/src/main/java/corecord/dev/domain/chat/application/ChatServiceImpl.java
+++ b/src/main/java/corecord/dev/domain/chat/application/ChatServiceImpl.java
@@ -8,7 +8,6 @@ import corecord.dev.domain.chat.domain.dto.response.ChatResponse;
 import corecord.dev.domain.chat.domain.dto.response.ChatSummaryAiResponse;
 import corecord.dev.domain.chat.domain.entity.Chat;
 import corecord.dev.domain.chat.domain.entity.ChatRoom;
-import corecord.dev.domain.chat.domain.repository.ChatRepository;
 import corecord.dev.domain.chat.exception.ChatException;
 import corecord.dev.domain.chat.status.ChatErrorStatus;
 import corecord.dev.domain.user.application.UserDbService;
@@ -70,6 +69,7 @@ public class ChatServiceImpl implements ChatService {
 
         // AI 답변 생성
         List<Chat> chatHistory = chatDbService.findChatsByChatRoom(chatRoom);
+        // TODO: VALID AI MAX TOKEN
         String aiAnswer = chatAIService.generateChatResponse(chatHistory, chatDto.getContent());
 
         // AI 답변 길이 제한 및 재생성

--- a/src/main/java/corecord/dev/domain/chat/domain/entity/Chat.java
+++ b/src/main/java/corecord/dev/domain/chat/domain/entity/Chat.java
@@ -23,7 +23,7 @@ public class Chat extends BaseEntity {
     @Column(name = "author", nullable = false)
     private Integer author; // 0(user), 1(ai)
 
-    @Column(name = "content", nullable = false, length = 500)
+    @Column(name = "content", nullable = false, length = 550)
     private String content;
 
     @ManyToOne


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #47 

### 💡 작업내용
- 역량 분석 도메인의 AI 관련 에러 코드 수정(400 -> 500)
- `Chat` entity content length 수정(500 -> 550)

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
