### PR TITLE
[Chore/#37] 예시 경험 폴더명 ENUM 생성

### DIFF
--- a/src/main/java/corecord/dev/domain/folder/application/FolderServiceImpl.java
+++ b/src/main/java/corecord/dev/domain/folder/application/FolderServiceImpl.java
@@ -7,6 +7,7 @@ import corecord.dev.domain.folder.domain.converter.FolderConverter;
 import corecord.dev.domain.folder.domain.dto.request.FolderRequest;
 import corecord.dev.domain.folder.domain.dto.response.FolderResponse;
 import corecord.dev.domain.folder.domain.entity.Folder;
+import corecord.dev.domain.folder.domain.enums.ExampleFolder;
 import corecord.dev.domain.folder.exception.FolderException;
 import corecord.dev.domain.folder.status.FolderErrorStatus;
 import corecord.dev.domain.record.application.RecordDbService;
@@ -119,7 +120,7 @@ public class FolderServiceImpl implements FolderService {
     @Override
     @Transactional
     public Folder createExampleFolder(User user) {
-        Folder folder = FolderConverter.toFolderEntity("경험 기록 예시 폴더", user);
+        Folder folder = FolderConverter.toFolderEntity(ExampleFolder.EXAMPLE.getValue(), user);
         folderDbService.saveFolder(folder);
         return folder;
     }

--- a/src/main/java/corecord/dev/domain/folder/domain/enums/ExampleFolder.java
+++ b/src/main/java/corecord/dev/domain/folder/domain/enums/ExampleFolder.java
@@ -1,0 +1,12 @@
+package corecord.dev.domain.folder.domain.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ExampleFolder {
+    EXAMPLE("경험 기록 예시 폴더");
+
+    private final String value;
+}

--- a/src/main/java/corecord/dev/domain/record/application/RecordDbService.java
+++ b/src/main/java/corecord/dev/domain/record/application/RecordDbService.java
@@ -2,11 +2,11 @@ package corecord.dev.domain.record.application;
 
 import corecord.dev.domain.ability.domain.enums.Keyword;
 import corecord.dev.domain.folder.domain.entity.Folder;
+import corecord.dev.domain.folder.domain.enums.ExampleFolder;
 import corecord.dev.domain.record.domain.entity.Record;
 import corecord.dev.domain.record.domain.repository.RecordRepository;
 import corecord.dev.domain.record.exception.RecordException;
 import corecord.dev.domain.record.status.RecordErrorStatus;
-import corecord.dev.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +22,7 @@ public class RecordDbService {
     private final RecordRepository recordRepository;
 
     private final int listSize = 30;
+    private final int recentListSize = 6;
 
     @Transactional
     public Record saveRecord(Record record) {
@@ -68,21 +69,21 @@ public class RecordDbService {
 
     public List<Record> findRecordListByFolder(Long userId, Folder folder, Long lastRecordId) {
         Pageable pageable = PageRequest.of(0, listSize + 1, Sort.by("createdAt").descending());
-        return recordRepository.findRecordsByFolder(folder, userId, lastRecordId, pageable);
+        return recordRepository.findRecordsByFolder(folder, userId, lastRecordId, ExampleFolder.EXAMPLE.getValue(), pageable);
     }
 
     public List<Record> findRecordList(Long userId, Long lastRecordId) {
         Pageable pageable = PageRequest.of(0, listSize + 1, Sort.by("createdAt").descending());
-        return recordRepository.findRecords(userId, lastRecordId, pageable);
+        return recordRepository.findRecords(userId, lastRecordId, ExampleFolder.EXAMPLE.getValue(), pageable);
     }
 
     public List<Record> findRecentRecordList(Long userId) {
-        Pageable pageable = PageRequest.of(0, 6, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(0, recentListSize, Sort.by("createdAt").descending());
         return recordRepository.findRecentRecords(userId, pageable);
     }
 
     public List<Record> findRecordListByKeyword(Long userId, Keyword keyword, Long lastRecordId) {
         Pageable pageable = PageRequest.of(0, listSize + 1, Sort.by("createdAt").descending());
-        return recordRepository.findRecordsByKeyword(keyword, userId, lastRecordId, pageable);
+        return recordRepository.findRecordsByKeyword(keyword, userId, lastRecordId, ExampleFolder.EXAMPLE.getValue(), pageable);
     }
 }

--- a/src/main/java/corecord/dev/domain/record/application/RecordDbService.java
+++ b/src/main/java/corecord/dev/domain/record/application/RecordDbService.java
@@ -45,11 +45,11 @@ public class RecordDbService {
     }
 
     public int getRecordCount(Long userId) {
-        return recordRepository.getRecordCount(userId);
+        return recordRepository.getRecordCount(userId, ExampleFolder.EXAMPLE.getValue());
     }
 
     public int getRecordCountByChatType(Long userId) {
-        return recordRepository.getRecordCountByType(userId);
+        return recordRepository.getRecordCountByType(userId, ExampleFolder.EXAMPLE.getValue());
     }
 
     @Transactional

--- a/src/main/java/corecord/dev/domain/record/domain/converter/RecordConverter.java
+++ b/src/main/java/corecord/dev/domain/record/domain/converter/RecordConverter.java
@@ -23,7 +23,6 @@ public class RecordConverter {
                 .folder(folder)
                 .chatRoom(chatRoom)
                 .type(recordType)
-                .isExample(isExample)
                 .build();
     }
 

--- a/src/main/java/corecord/dev/domain/record/domain/entity/Record.java
+++ b/src/main/java/corecord/dev/domain/record/domain/entity/Record.java
@@ -36,10 +36,6 @@ public class Record extends BaseEntity {
     @Column(name = "content", nullable = false, length = 500)
     private String content;
 
-    @Column(name = "is_example")
-    @ColumnDefault("'0'")
-    private char isExample;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;

--- a/src/main/java/corecord/dev/domain/record/domain/repository/RecordRepository.java
+++ b/src/main/java/corecord/dev/domain/record/domain/repository/RecordRepository.java
@@ -3,7 +3,6 @@ package corecord.dev.domain.record.domain.repository;
 import corecord.dev.domain.ability.domain.enums.Keyword;
 import corecord.dev.domain.folder.domain.entity.Folder;
 import corecord.dev.domain.record.domain.entity.Record;
-import corecord.dev.domain.user.domain.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -27,11 +26,12 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             "AND (:last_record_id = 0 OR r.recordId < :last_record_id) " +  // 제일 마지막에 읽은 데이터 이후부터 가져옴
             "AND r.folder is not null " + // 임시 저장 기록 제외
             "AND r.folder = :folder " +
-            "AND r.folder.title <> '경험 기록 예시 폴더'") // 예시 경험 기록 제외
+            "AND r.folder.title <> :example_folder_name") // 예시 경험 기록 제외
     List<Record> findRecordsByFolder(
             @Param(value = "folder") Folder folder,
             @Param(value = "userId") Long userId,
             @Param(value = "last_record_id") Long lastRecordId,
+            @Param(value = "example_folder_name") String exampleFolderName,
             Pageable pageable);
 
     @Query("SELECT r FROM Record r " +
@@ -42,10 +42,11 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             "WHERE u.userId = :userId " +
             "AND (:last_record_id <= 0 OR r.recordId < :last_record_id) " + // 제일 마지막에 읽은 데이터 이후부터 가져옴
             "AND r.folder is not null " + // 임시 저장 기록 제외
-            "AND r.folder.title <> '경험 기록 예시 폴더'") // 예시 경험 기록 제외
+            "AND r.folder.title <> :example_folder_name") // 예시 경험 기록 제외
     List<Record> findRecords(
             @Param(value = "userId") Long userId,
             @Param(value = "last_record_id") Long lastRecordId,
+            @Param(value = "example_folder_name") String exampleFolderName,
             Pageable pageable);
 
     @Query("SELECT r FROM Record r " +
@@ -66,11 +67,13 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             "WHERE a.user.userId = :userId " +
             "AND a.keyword = :keyword " +
             "AND (:last_record_id = 0 OR r.recordId < :last_record_id) " + // 제일 마지막에 읽은 데이터 이후부터 가져옴
-            "AND r.folder is not null") // 임시 저장 기록 제외
+            "AND r.folder is not null " + // 임시 저장 기록 제외
+            "AND r.folder.title <> :example_folder_name") // 예시 경험 기록 제외
     List<Record> findRecordsByKeyword(
             @Param(value = "keyword")Keyword keyword,
             @Param(value = "userId") Long userId,
             @Param(value = "last_record_id") Long lastRecordId,
+            @Param(value = "example_folder_name") String exampleFolderName,
             Pageable pageable
             );
 

--- a/src/main/java/corecord/dev/domain/record/domain/repository/RecordRepository.java
+++ b/src/main/java/corecord/dev/domain/record/domain/repository/RecordRepository.java
@@ -86,17 +86,19 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
     @Query("SELECT COUNT(r) " +
             "FROM Record r " +
             "WHERE r.user.userId = :userId " +
-            "AND r.isExample = '0' " + // 예시 기록 제외
-            "AND r.folder is not null") // 임시 저장 기록 제외
-    int getRecordCount(@Param(value = "userId") Long userId);
+            "AND r.folder is not null " + // 임시 저장 기록 제외
+            "AND r.folder.title <> :example_folder_name") // 예시 기록 제외
+    int getRecordCount(@Param(value = "userId") Long userId,
+                       @Param(value = "example_folder_name") String exampleFolderName);
 
     @Query("SELECT COUNT(r) " +
             "FROM Record r " +
             "WHERE r.user.userId = :userId " +
-            "AND r.isExample = '0' " + // 예시 기록 제외
             "AND r.folder is not null " + // 임시 저장 기록 제외
+            "AND r.folder.title <> :example_folder_name " + // 예시 기록 제외
             "AND r.type = 'CHAT' ")
-    int getRecordCountByType(@Param(value = "userId") Long userId);
+    int getRecordCountByType(@Param(value = "userId") Long userId,
+                             @Param(value = "example_folder_name") String exampleFolderName);
 
     @Modifying
     @Query("DELETE " +

--- a/src/test/java/corecord/dev/record/memo/repository/MemoRecordRepositoryTest.java
+++ b/src/test/java/corecord/dev/record/memo/repository/MemoRecordRepositoryTest.java
@@ -6,6 +6,7 @@ import corecord.dev.domain.ability.domain.repository.AbilityRepository;
 import corecord.dev.domain.analysis.domain.entity.Analysis;
 import corecord.dev.domain.analysis.domain.repository.AnalysisRepository;
 import corecord.dev.domain.folder.domain.entity.Folder;
+import corecord.dev.domain.folder.domain.enums.ExampleFolder;
 import corecord.dev.domain.folder.domain.repository.FolderRepository;
 import corecord.dev.domain.record.domain.enums.RecordType;
 import corecord.dev.domain.record.domain.entity.Record;
@@ -66,7 +67,7 @@ public class MemoRecordRepositoryTest {
         Record record2 = createRecord("Test Record2", user, folder);
 
         // When
-        List<Record> result = recordRepository.findRecordsByFolder(folder, user.getUserId(), lastRecordId, pageable);
+        List<Record> result = recordRepository.findRecordsByFolder(folder, user.getUserId(), lastRecordId, ExampleFolder.EXAMPLE.getValue(), pageable);
 
         // Then
         assertThat(result.size()).isEqualTo(2);
@@ -84,7 +85,7 @@ public class MemoRecordRepositoryTest {
         Folder folder = createFolder("Test Folder", user);
 
         // When
-        List<Record> result = recordRepository.findRecordsByFolder(folder, user.getUserId(), lastRecordId, pageable);
+        List<Record> result = recordRepository.findRecordsByFolder(folder, user.getUserId(), lastRecordId, ExampleFolder.EXAMPLE.getValue(), pageable);
 
         // Then
         assertEquals(result.size(), 0);
@@ -118,7 +119,7 @@ public class MemoRecordRepositoryTest {
         Record record2 = createRecord("Test Record2", user, folder);
 
         // When
-        List<Record> result = recordRepository.findRecordsByKeyword(Keyword.COLLABORATION, user.getUserId(), lastRecordId, pageable);
+        List<Record> result = recordRepository.findRecordsByKeyword(Keyword.COLLABORATION, user.getUserId(), lastRecordId, ExampleFolder.EXAMPLE.getValue(), pageable);
 
         // Then
         assertEquals(result.size(), 2);


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #37

### 💡 작업내용
- 예시용 경험 생성을 위한 폴더명 ENUM으로 관리
  - string 하드 코딩보다 enum이 관리하기 용이할 것 같아 변경합니다! 
- Record entity : `is_example` field 제거
  - field값이 아닌 해당 record가 속한 폴더의 이름으로 조회 범위 관리 


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
