### PR TITLE
[Refactor/#51] 경험 기록 조회 API 수정

### DIFF
--- a/src/main/java/corecord/dev/domain/ability/domain/entity/Ability.java
+++ b/src/main/java/corecord/dev/domain/ability/domain/entity/Ability.java
@@ -17,8 +17,9 @@ import org.hibernate.annotations.ColumnDefault;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "ability",
-        indexes = {@Index(name = "user_keyword_created_idx", columnList = "user_id, keyword, created_at"),
-        @Index(name = "ability_analysis_idx", columnList = "analysis_id, user_id, keyword")})
+        indexes = {@Index(name = "user_is_example_keyword_created_idx", columnList = "user_id, is_example, keyword, created_at"),
+                @Index(name = "ability_keyword_analysis_idx", columnList = "user_id, keyword, is_example, analysis_id, created_at"),
+                @Index(name = "ability_analysis_idx", columnList = "analysis_id, user_id, keyword")})
 public class Ability extends BaseEntity {
 
     @Id

--- a/src/main/java/corecord/dev/domain/ability/domain/repository/AbilityRepository.java
+++ b/src/main/java/corecord/dev/domain/ability/domain/repository/AbilityRepository.java
@@ -17,13 +17,13 @@ public interface AbilityRepository extends JpaRepository<Ability, Long> {
         @Query("SELECT new corecord.dev.domain.ability.domain.dto.response.AbilityResponse$KeywordStateDto(" +
                 "a.keyword, COUNT(a), " + // 각 키워드의 개수 집계
                 "(COUNT(a) * 1.0 / (SELECT COUNT(a2) FROM Ability a2 " +
-                "WHERE a2.user.userId = :userId AND a2.isExample = '0')) * 100.0) " + // 각 키워드의 비율 집계
+                        "WHERE a2.user.userId = :userId AND a2.isExample = '0')) * 100.0) " + // 각 키워드의 비율 집계
                 "FROM Ability a " +
                 "WHERE a.user.userId = :userId " +
                 "AND a.isExample = '0' " +
                 "GROUP BY a.keyword " +
                 "ORDER BY COUNT(a) DESC, MAX(a.createdAt) DESC ") // 개수 많은 순 정렬
-        List<AbilityResponse.KeywordStateDto> findKeywordStateDtoList(@Param(value = "userId") Long userId);
+List<AbilityResponse.KeywordStateDto> findKeywordStateDtoList(@Param(value = "userId") Long userId);
 
         @Modifying
         @Query("DELETE " +
@@ -37,12 +37,14 @@ public interface AbilityRepository extends JpaRepository<Ability, Long> {
                 "WHERE a.analysis.record.folder = :folder")
         void deleteAbilityByFolder(@Param(value = "folder") Folder folder);
 
-        @Query("SELECT distinct a.keyword AS keyword " + // unique한 keyword list 반환
-                "FROM Ability a " +
-                "JOIN a.analysis ana " +
-                "WHERE a.user.userId = :userId " +
-                "AND a.isExample = '0' " +
-                "GROUP BY a.keyword " +
-                "ORDER BY COUNT(a.keyword) DESC, MAX(ana.createdAt) DESC ") // 개수가 많은 순, 최근 생성 순 정렬
+        @Query("SELECT a1_0.keyword " +
+                "FROM ( " +
+                "    SELECT a.keyword AS keyword , COUNT(*) AS ability_count, MAX(a.createdAt) AS latest_created_at " +
+                "    FROM Ability a " +
+                "    WHERE a.user.userId = :userId " +
+                "    AND a.isExample = '0' " +
+                "    GROUP BY a.keyword " +
+                ") a1_0 " +
+                "ORDER BY a1_0.ability_count DESC, a1_0.latest_created_at DESC")
         List<Keyword> getKeywordList(@Param(value = "userId") Long userId);
 }

--- a/src/main/java/corecord/dev/domain/analysis/domain/converter/AnalysisConverter.java
+++ b/src/main/java/corecord/dev/domain/analysis/domain/converter/AnalysisConverter.java
@@ -4,7 +4,6 @@ import corecord.dev.domain.ability.domain.converter.AbilityConverter;
 import corecord.dev.domain.ability.domain.dto.response.AbilityResponse;
 import corecord.dev.domain.analysis.domain.dto.response.AnalysisResponse;
 import corecord.dev.domain.analysis.domain.entity.Analysis;
-import corecord.dev.domain.record.domain.enums.RecordType;
 import corecord.dev.domain.record.domain.entity.Record;
 
 import java.util.List;
@@ -28,7 +27,7 @@ public class AnalysisConverter {
 
         return AnalysisResponse.AnalysisDto.builder()
                 .analysisId(analysis.getAnalysisId())
-                .chatRoomId(record.getType() == RecordType.CHAT ? record.getChatRoom().getChatRoomId() : null)
+                .chatRoomId(record.isMemoType() ? null : record.getChatRoom().getChatRoomId())
                 .recordId(record.getRecordId())
                 .recordType(record.getType())
                 .folderName(record.getFolder().getTitle())

--- a/src/main/java/corecord/dev/domain/chat/application/ChatServiceImpl.java
+++ b/src/main/java/corecord/dev/domain/chat/application/ChatServiceImpl.java
@@ -199,14 +199,14 @@ public class ChatServiceImpl implements ChatService {
     public ChatResponse.ChatTmpDto getChatTmp(Long userId) {
         User user = userDbService.findUserById(userId);
         if (user.getTmpChat() == null) {
-            return ChatConverter.toNotExistingChatTmpDto();
+            return ChatConverter.toChatTmpDto(null);
         }
 
         // 임시 채팅 제거 후 반환
         Long chatRoomId = user.getTmpChat();
         userDbService.deleteUserTmpChat(user);
 
-        return ChatConverter.toExistingChatTmpDto(chatRoomId);
+        return ChatConverter.toChatTmpDto(chatRoomId);
     }
 
     /**

--- a/src/main/java/corecord/dev/domain/chat/domain/converter/ChatConverter.java
+++ b/src/main/java/corecord/dev/domain/chat/domain/converter/ChatConverter.java
@@ -48,7 +48,7 @@ public class ChatConverter {
     public static ChatResponse.ChatDetailDto toChatDetailDto(Chat chat) {
         return ChatResponse.ChatDetailDto.builder()
                 .chatId(chat.getChatId())
-                .author(chat.getAuthor() == 0 ? "ai" : "user")
+                .author(chat.isAiAuthor() ? "ai" : "user")
                 .content(chat.getContent())
                 .created_at(chat.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
                 .build();
@@ -56,7 +56,8 @@ public class ChatConverter {
 
     public static ChatResponse.ChatListDto toChatListDto(List<Chat> chatList) {
         return ChatResponse.ChatListDto.builder()
-                .chats(chatList.stream().map(ChatConverter::toChatDetailDto).toList())
+                .chats(chatList.stream()
+                        .map(ChatConverter::toChatDetailDto).toList())
                 .build();
     }
 
@@ -68,17 +69,10 @@ public class ChatConverter {
                 .build();
     }
 
-    public static ChatResponse.ChatTmpDto toExistingChatTmpDto(Long chatRoomId) {
+    public static ChatResponse.ChatTmpDto toChatTmpDto(Long chatRoomId) {
         return ChatResponse.ChatTmpDto.builder()
-                .isExist(true)
+                .isExist(chatRoomId != null)
                 .chatRoomId(chatRoomId)
-                .build();
-    }
-
-    public static ChatResponse.ChatTmpDto toNotExistingChatTmpDto() {
-        return ChatResponse.ChatTmpDto.builder()
-                .isExist(false)
-                .chatRoomId(null)
                 .build();
     }
 }

--- a/src/main/java/corecord/dev/domain/chat/domain/entity/Chat.java
+++ b/src/main/java/corecord/dev/domain/chat/domain/entity/Chat.java
@@ -21,7 +21,7 @@ public class Chat extends BaseEntity {
     private Long chatId;
 
     @Column(name = "author", nullable = false)
-    private Integer author; // 0(user), 1(ai)
+    private Integer author; // 0(ai), 1(user)
 
     @Column(name = "content", nullable = false, length = 550)
     private String content;
@@ -29,4 +29,8 @@ public class Chat extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "chat_room_id", nullable = false)
     private ChatRoom chatRoom;
+
+    public boolean isAiAuthor() {
+        return this.author == 0;
+    }
 }

--- a/src/main/java/corecord/dev/domain/record/application/RecordDbService.java
+++ b/src/main/java/corecord/dev/domain/record/application/RecordDbService.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -68,22 +69,32 @@ public class RecordDbService {
     }
 
     public List<Record> findRecordListByFolder(Long userId, Folder folder, Long lastRecordId) {
-        Pageable pageable = PageRequest.of(0, listSize + 1, Sort.by("createdAt").descending());
-        return recordRepository.findRecordsByFolder(folder, userId, lastRecordId, ExampleFolder.EXAMPLE.getValue(), pageable);
+        Pageable pageable = PageRequest.of(0, listSize + 1);
+        List<Long> recordIds = recordRepository.findRecordIdsByFolder(folder, userId, lastRecordId, ExampleFolder.EXAMPLE.getValue(), pageable);
+        return getRecordListResult(recordIds);
     }
 
     public List<Record> findRecordList(Long userId, Long lastRecordId) {
-        Pageable pageable = PageRequest.of(0, listSize + 1, Sort.by("createdAt").descending());
-        return recordRepository.findRecords(userId, lastRecordId, ExampleFolder.EXAMPLE.getValue(), pageable);
+        Pageable pageable = PageRequest.of(0, listSize + 1);
+        List<Long> recordIds = recordRepository.findRecordIds(userId, lastRecordId, ExampleFolder.EXAMPLE.getValue(), pageable);
+        return getRecordListResult(recordIds);
     }
 
     public List<Record> findRecentRecordList(Long userId) {
         Pageable pageable = PageRequest.of(0, recentListSize, Sort.by("createdAt").descending());
-        return recordRepository.findRecentRecords(userId, pageable);
+        List<Long> recordIds = recordRepository.findRecentRecordIds(userId, pageable);
+        return getRecordListResult(recordIds);
     }
 
     public List<Record> findRecordListByKeyword(Long userId, Keyword keyword, Long lastRecordId) {
         Pageable pageable = PageRequest.of(0, listSize + 1, Sort.by("createdAt").descending());
         return recordRepository.findRecordsByKeyword(keyword, userId, lastRecordId, ExampleFolder.EXAMPLE.getValue(), pageable);
+    }
+
+    private List<Record> getRecordListResult(List<Long> recordIds) {
+        if (recordIds.isEmpty()) {
+            return new ArrayList<>(); // 결과 없을 경우 빈 리스트 반환
+        }
+        return recordRepository.findRecordsByIds(recordIds);
     }
 }

--- a/src/main/java/corecord/dev/domain/record/application/RecordServiceImpl.java
+++ b/src/main/java/corecord/dev/domain/record/application/RecordServiceImpl.java
@@ -73,7 +73,7 @@ public class RecordServiceImpl implements RecordService {
         if (recordDto.getChatRoomId() != null) {
             chatRoom = chatDbService.findChatRoomById(recordDto.getChatRoomId(), user.getUserId());
         }
-        return RecordConverter.toRecordEntity(recordDto.getTitle(), recordDto.getContent(), user, folder, chatRoom, recordDto.getRecordType(), '0');
+        return RecordConverter.toRecordEntity(recordDto.getTitle(), recordDto.getContent(), user, folder, chatRoom, recordDto.getRecordType());
     }
 
     private int getChatRecordCount(Record record, Long userId) {
@@ -117,7 +117,7 @@ public class RecordServiceImpl implements RecordService {
         validTextLength(title, content);
 
         // Record entity 생성 후 user.tmpMemo 필드에 recordId 저장
-        Record record = RecordConverter.toRecordEntity(title, content, user, null, null, RecordType.MEMO, '0');
+        Record record = RecordConverter.toRecordEntity(title, content, user, null, null, RecordType.MEMO);
         Record tmpRecord = recordDbService.saveRecord(record);
         user.updateTmpMemo(tmpRecord.getRecordId());
     }
@@ -266,7 +266,7 @@ public class RecordServiceImpl implements RecordService {
         String content = recordNode.path("content").asText();
 
         // record 저장
-        Record record = RecordConverter.toRecordEntity(title, content, user, folder, chatRoom, RecordType.CHAT, '1');
+        Record record = RecordConverter.toRecordEntity(title, content, user, folder, chatRoom, RecordType.CHAT);
         recordDbService.saveRecord(record);
 
         analysisService.createExampleAnalysis(user, record);

--- a/src/main/java/corecord/dev/domain/record/application/RecordServiceImpl.java
+++ b/src/main/java/corecord/dev/domain/record/application/RecordServiceImpl.java
@@ -114,7 +114,6 @@ public class RecordServiceImpl implements RecordService {
 
         // User의 임시 메모 저장 유무 확인
         validHasUserTmpMemo(user);
-
         validTextLength(title, content);
 
         // Record entity 생성 후 user.tmpMemo 필드에 recordId 저장
@@ -143,7 +142,7 @@ public class RecordServiceImpl implements RecordService {
 
         // 임시 저장 내역이 없는 경우 isExist=false 반환
         if (tmpMemoRecordId == null) {
-            return RecordConverter.toNotExistingTmpMemoRecordDto();
+            return RecordConverter.toTmpMemoRecordDto(null);
         }
 
         // 임시 저장 내역이 있는 경우 결과 조회
@@ -152,7 +151,7 @@ public class RecordServiceImpl implements RecordService {
         // 기존 데이터 제거 후 결과 반환
         user.deleteTmpMemo();
         recordDbService.deleteRecord(tmpMemoRecord);
-        return RecordConverter.toExistingTmpMemoRecordDto(tmpMemoRecord);
+        return RecordConverter.toTmpMemoRecordDto(tmpMemoRecord);
     }
 
     /**

--- a/src/main/java/corecord/dev/domain/record/domain/converter/RecordConverter.java
+++ b/src/main/java/corecord/dev/domain/record/domain/converter/RecordConverter.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 public class RecordConverter {
     public static Record toRecordEntity(String title, String content, User user,
-                                        Folder folder, ChatRoom chatRoom, RecordType recordType, char isExample) {
+                                        Folder folder, ChatRoom chatRoom, RecordType recordType) {
         return Record.builder()
                 .title(title)
                 .user(user)

--- a/src/main/java/corecord/dev/domain/record/domain/converter/RecordConverter.java
+++ b/src/main/java/corecord/dev/domain/record/domain/converter/RecordConverter.java
@@ -36,19 +36,11 @@ public class RecordConverter {
                 .build();
     }
 
-    public static RecordResponse.TmpMemoRecordDto toExistingTmpMemoRecordDto(Record record) {
+    public static RecordResponse.TmpMemoRecordDto toTmpMemoRecordDto(Record record) {
         return RecordResponse.TmpMemoRecordDto.builder()
-                .isExist(true)
-                .title(record.getTitle())
-                .content(record.getContent())
-                .build();
-    }
-
-    public static RecordResponse.TmpMemoRecordDto toNotExistingTmpMemoRecordDto() {
-        return RecordResponse.TmpMemoRecordDto.builder()
-                .isExist(false)
-                .title(null)
-                .content(null)
+                .isExist(record != null)
+                .title(record == null ? null : record.getTitle())
+                .content(record == null ? null : record.getContent())
                 .build();
     }
 

--- a/src/main/java/corecord/dev/domain/record/domain/entity/Record.java
+++ b/src/main/java/corecord/dev/domain/record/domain/entity/Record.java
@@ -11,7 +11,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter @Builder

--- a/src/main/java/corecord/dev/domain/record/domain/entity/Record.java
+++ b/src/main/java/corecord/dev/domain/record/domain/entity/Record.java
@@ -17,8 +17,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "record",
-        indexes = {@Index(name = "created_at_idx", columnList = "created_at"),
-        @Index(name = "user_created_at_idx", columnList = "user_id, created_at")})
+        indexes = {@Index(name = "user_created_at_idx", columnList = "user_id, created_at desc, record_id")})
 public class Record extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/corecord/dev/domain/record/domain/repository/RecordRepository.java
+++ b/src/main/java/corecord/dev/domain/record/domain/repository/RecordRepository.java
@@ -16,47 +16,37 @@ import java.util.Optional;
 @Repository
 public interface RecordRepository extends JpaRepository<Record, Long> {
 
-    @Query("SELECT r " +
-            "FROM Record r " +
-            "JOIN FETCH r.analysis a " +
-            "JOIN FETCH r.folder f " +
-            "JOIN FETCH a.abilityList al " +
+    @Query("SELECT r.recordId FROM Record r " +
             "JOIN r.user u " +
             "WHERE u.userId = :userId " +
             "AND (:last_record_id = 0 OR r.recordId < :last_record_id) " +  // 제일 마지막에 읽은 데이터 이후부터 가져옴
             "AND r.folder is not null " + // 임시 저장 기록 제외
             "AND r.folder = :folder " +
             "AND r.folder.title <> :example_folder_name") // 예시 경험 기록 제외
-    List<Record> findRecordsByFolder(
+    List<Long> findRecordIdsByFolder(
             @Param(value = "folder") Folder folder,
             @Param(value = "userId") Long userId,
             @Param(value = "last_record_id") Long lastRecordId,
             @Param(value = "example_folder_name") String exampleFolderName,
             Pageable pageable);
 
-    @Query("SELECT r FROM Record r " +
-            "JOIN FETCH r.analysis a " +
-            "JOIN FETCH r.folder f " +
-            "JOIN FETCH a.abilityList al " +
+    @Query("SELECT r.recordId FROM Record r " +
             "JOIN r.user u " +
             "WHERE u.userId = :userId " +
             "AND (:last_record_id <= 0 OR r.recordId < :last_record_id) " + // 제일 마지막에 읽은 데이터 이후부터 가져옴
             "AND r.folder is not null " + // 임시 저장 기록 제외
             "AND r.folder.title <> :example_folder_name") // 예시 경험 기록 제외
-    List<Record> findRecords(
+    List<Long> findRecordIds(
             @Param(value = "userId") Long userId,
             @Param(value = "last_record_id") Long lastRecordId,
             @Param(value = "example_folder_name") String exampleFolderName,
             Pageable pageable);
 
-    @Query("SELECT r FROM Record r " +
-            "JOIN FETCH r.analysis a " +
-            "JOIN FETCH r.folder f " +
-            "JOIN FETCH a.abilityList al " +
+    @Query("SELECT r.recordId FROM Record r " +
             "JOIN r.user u " +
             "WHERE u.userId = :userId " +
             "AND r.folder is not null") // 임시 저장 기록 제외
-    List<Record> findRecentRecords(
+    List<Long> findRecentRecordIds(
             @Param(value = "userId") Long userId,
             Pageable pageable);
 
@@ -76,6 +66,15 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             @Param(value = "example_folder_name") String exampleFolderName,
             Pageable pageable
             );
+
+    @Query("SELECT DISTINCT r FROM Record r " +
+            "JOIN FETCH r.analysis a " +
+            "JOIN FETCH r.folder f " +
+            "JOIN FETCH a.abilityList al " +
+            "JOIN FETCH r.user u " +
+            "WHERE r.recordId IN :record_ids " +
+            "ORDER BY r.createdAt DESC")
+    List<Record> findRecordsByIds(@Param("record_ids") List<Long> recordIds);
 
     @Query("SELECT r FROM Record r " +
             "JOIN FETCH r.analysis a " +

--- a/src/main/java/corecord/dev/domain/record/domain/repository/RecordRepository.java
+++ b/src/main/java/corecord/dev/domain/record/domain/repository/RecordRepository.java
@@ -51,14 +51,13 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             Pageable pageable);
 
     @Query("SELECT r FROM Ability a " +
-            "JOIN a.analysis an " +
-            "JOIN an.record r " +
+            "JOIN a.analysis.record r " +
             "JOIN FETCH r.folder f " +
             "WHERE a.user.userId = :userId " +
             "AND a.keyword = :keyword " +
             "AND (:last_record_id = 0 OR r.recordId < :last_record_id) " + // 제일 마지막에 읽은 데이터 이후부터 가져옴
             "AND r.folder is not null " + // 임시 저장 기록 제외
-            "AND r.folder.title <> :example_folder_name") // 예시 경험 기록 제외
+            "AND r.folder.title NOT IN (:example_folder_name)") // 예시 경험 기록 제외
     List<Record> findRecordsByKeyword(
             @Param(value = "keyword")Keyword keyword,
             @Param(value = "userId") Long userId,
@@ -67,7 +66,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
             Pageable pageable
             );
 
-    @Query("SELECT DISTINCT r FROM Record r " +
+    @Query("SELECT r FROM Record r " +
             "JOIN FETCH r.analysis a " +
             "JOIN FETCH r.folder f " +
             "JOIN FETCH a.abilityList al " +


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #51 

### 💡 작업내용
- 경험 기록 조회 API 2단계로 분리
  - 기존 : fetch join + @ 로 한 개의 쿼리만 수행되나, paging + fetch로 인한 memory sort 발생 -> 데이터 개수가 많아질 경우 성능 저하 우려
  - 변경 : (1) recordId 조회 + paging 적용 -> (2) fetch + order by 기반 sort 
- converter 중 중복되거나 불필요한 함수 제거
- 불필요한 idx 제거 및 idx 추가


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
- 데이터 양이 많지 않아 눈에 띄는 성능 차이는 없을 것 같습니다
- null 확인이나 folder title 확인 때문에 인덱스를 제대로 활용하지 못하는 경우도 있는데, 나중에 어떻게 수정해야 할지 고민됩니다 .. ㅜㅜ