### PR TITLE
[Fix/#54] : redis 분산락으로 회원가입 시 중복 유저 생성 문제 해결

### DIFF
--- a/src/main/java/corecord/dev/common/util/RedisLockUtil.java
+++ b/src/main/java/corecord/dev/common/util/RedisLockUtil.java
@@ -1,0 +1,24 @@
+package corecord.dev.common.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Component
+public class RedisLockUtil {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public boolean acquireLock(String key, long timeout) {
+        ValueOperations<String, String> ops = redisTemplate.opsForValue();
+        return ops.setIfAbsent(key, "LOCKED", timeout, TimeUnit.SECONDS); // key가 없으면 true, 이미 있으면 false
+    }
+
+    public void releaseLock(String key) {
+        redisTemplate.delete(key);
+    }
+}


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #54 

### 💡 작업내용
- 기존에 DB에 중복 providerId 검사로 해두었던 중복 회원가입 방지가 따닥 연속으로 누를때에는 DB에 생성 전에 검사를 하게 되어서 해결되지 않은 부분을 발견했습니다.
- 원래는 redis에 registerToken을 저장하여 검사하는 방식으로 고치려고 했으나 테스트 해보니 여전히 문제가 발생하여, redis를 이용한 분산 락을 구현하여 해결하였습니다.
- 같은 providerId로 요청이 들어왔을때 5초 동안 동일 providerId의 요청을 막게 했습니다. (5초 정도면 DB에 충분히 저장이 됐을 것이라 생각)
- jmeter로 1초에 30번 register 요청이 들어왔을때 1번만 처리되는 것 확인하였습니다. (기존엔 여러번 처리됐었음)

### 📸 스크린샷(선택)
<img width="1194" alt="스크린샷 2025-03-10 오후 10 12 02" src="https://github.com/user-attachments/assets/a5e56a01-750b-4378-b38b-e6cf0dd8ed95" />
<img width="349" alt="스크린샷 2025-03-10 오후 10 39 28" src="https://github.com/user-attachments/assets/84028227-5bdb-48b2-b19f-1b746b058ea0" />

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
